### PR TITLE
Fix configuration file syntax errors

### DIFF
--- a/.github/workflows/automerge-dependabot.yml
+++ b/.github/workflows/automerge-dependabot.yml
@@ -3,6 +3,7 @@ on:
   pull_request:
     types: [opened]
   pull_request_target:
+    types: [opened]
 permissions:
   contents: write
   pull-requests: write

--- a/Home/.config/fastfetch/config-bak.jsonc
+++ b/Home/.config/fastfetch/config-bak.jsonc
@@ -15,6 +15,6 @@
     "memory",
     "swap",
     "disk",
-    "localip",
+    "localip"
   ]
 }

--- a/Home/.config/sheldon/plugins.toml
+++ b/Home/.config/sheldon/plugins.toml
@@ -4,9 +4,6 @@ shell = "zsh"
 github = "zsh-users/zsh-autosuggestions"
 use = ["{{ name }}.zsh"]
 
-[plugins.zsh-autosuggestions]
-github = "zsh-users/zsh-autosuggestions"
-
 [plugins.fast-syntax-highlighting]
 github = "zdharma-continuum/fast-syntax-highlighting"
 


### PR DESCRIPTION
Fixed multiple config file issues discovered during repo scan:

- sheldon/plugins.toml: Removed duplicate [plugins.zsh-autosuggestions] section that was causing TOML parse error

- fastfetch/config-bak.jsonc: Removed trailing comma after "localip" which caused JSON syntax error

- automerge-dependabot.yml: Added missing types configuration to pull_request_target trigger for consistency with pull_request trigger

All fixes validated with syntax checkers.