### PR TITLE
Standardize bash scripts with consistent function syntax and bashisms

### DIFF
--- a/Home/.local/bin/autostart.sh
+++ b/Home/.local/bin/autostart.sh
@@ -49,7 +49,7 @@ for FILE in $FILES; do
         if [ -f "$AUTOSTART_DIR/$FILE" ]; then
                 while IFS= read -r PROGRAM; do
                         # spawn detached program
-                        nohup "$PROGRAM" >/dev/null 2>&1 &
+                        nohup "$PROGRAM" &>/dev/null &
                 done < "$AUTOSTART_DIR/$FILE"
         else
                 printf '%s\n' "Warning: File '$FILE' does not exist."

--- a/Home/.local/bin/doasedit.sh
+++ b/Home/.local/bin/doasedit.sh
@@ -57,12 +57,12 @@ for editor_cmd in "${DOAS_EDITOR}" "${VISUAL}" "${EDITOR}"; do
 done
 # shellcheck disable=SC2086
 if [ -z "${editor_cmd}" ]; then
-	if command -v vi > /dev/null 2>&1; then
+	if command -v vi &>/dev/null; then
 		editor_cmd='vi'
 	else
 		error 'no editor specified'; exit 1
 	fi
-elif ! command -v ${editor_cmd} > /dev/null 2>&1; then
+elif ! command -v ${editor_cmd} &>/dev/null; then
 	error "invalid editor command: '${editor_cmd}'"; exit 1
 fi
 exit_code=1

--- a/Home/.local/bin/fmenu.sh
+++ b/Home/.local/bin/fmenu.sh
@@ -33,5 +33,5 @@ fzf \
 
 # spawn detached program
 while IFS= read -r CMD; do
-        nohup "$CMD" >/dev/null 2>&1 &
+        nohup "$CMD" &>/dev/null &
 done

--- a/Home/.local/bin/fzpacman.sh
+++ b/Home/.local/bin/fzpacman.sh
@@ -8,7 +8,7 @@
 if [ "$1" = "-h" ]; then
   sed "1,2d;s/^# //;s/^#$/ /;/^$/ q" "$0"; exit 0
 fi
-if command -v pacman > /dev/null 2>&1; then
+if command -v pacman &>/dev/null; then
   LIST='pacman -Sl'
   INSTALL='sudo pacman -Sy {+2}'
   DOWNLOAD='sudo pacman -Syw {+2}'

--- a/Home/.local/bin/opt-pdf.sh
+++ b/Home/.local/bin/opt-pdf.sh
@@ -93,7 +93,7 @@ while [ $# -gt 0 ]; do
 
   # skip already-processed files
   if [ "$FORCE" = 'n' ]; then
-    command -v pdfinfo > /dev/null
+    command -v pdfinfo &>/dev/null
     if [ $? -eq 0 ]; then
       TMPPDF0=$(tempname opt-pdf_$$) || exit 99
       pdfinfo "$1" > $TMPPDF0

--- a/Home/.local/bin/search.sh
+++ b/Home/.local/bin/search.sh
@@ -35,7 +35,7 @@ QUERY="$(\
         --header="$(printf '%s\n' 'enter:print-query ctrl-o:open-from-history' "$FZF_DEFAULT_HEADER")" \
         --delimiter '|' --accept-nth="2" \
         --bind='enter:print-query' \
-        --bind='ctrl-o:become:nohup $BROWSER {1}{2} >/dev/null 2>&1 &' \
+        --bind='ctrl-o:become:nohup $BROWSER {1}{2} &>/dev/null &' \
         --query="$*"\
 )"
 
@@ -60,7 +60,7 @@ esac
 
 if [ -n "$QUERY" ]; then
         printf '%s\n' "$ENGINE|$QUERY|$(date "+%y/%m/%d-%H:%M:%S")" >> "$SEARCH_HIST_FILE";
-        nohup "$BROWSER" "$ENGINE$QUERY" >/dev/null 2>&1 &
+        nohup "$BROWSER" "$ENGINE$QUERY" &>/dev/null &
 else
         printf '%s\n' "No query!"; exit 1
 fi

--- a/Home/.local/bin/shopt.sh
+++ b/Home/.local/bin/shopt.sh
@@ -93,7 +93,7 @@ optimize(){
     content=$(sd '\s*\(\)\s*\{' '(){' <<<"$content")
     content=$(sd '>\/dev\/null 2>&1' '\&>/dev/null' <<<"$content")
   else
-    content=$(sed -e 's/|| true/|| :/g' -e 's/[[:space:]]*()[[:space:]]*{/(){/g' -e 's|>/dev/null 2>&1|\&>/dev/null|g' <<<"$content")
+    content=$(sed -e 's/|| :/|| :/g' -e 's/[[:space:]]*()[[:space:]]*{/(){/g' -e 's|&>/dev/null|\&>/dev/null|g' <<<"$content")
   fi
   # Format/Minify
   if (( format )); then

--- a/Home/.local/bin/transcode.sh
+++ b/Home/.local/bin/transcode.sh
@@ -32,8 +32,8 @@ format-drive(){ if [[ $# -ne 2 ]]; then
       sudo parted -s "$1" mkpart primary 1MiB 100%
 
       partition="$([[ $1 == *"nvme"* ]] && echo "${1}p1" || echo "${1}1")"
-      sudo partprobe "$1" || true
-      sudo udevadm settle || true
+      sudo partprobe "$1" || :
+      sudo udevadm settle || :
 
       sudo mkfs.exfat -n "$2" "$partition"
 

--- a/Home/.local/bin/wp.sh
+++ b/Home/.local/bin/wp.sh
@@ -23,13 +23,13 @@ mkdir -p "$AUTOSTART_DIR" # create directory if it doesn't already exist
 
 ### define functions ###
 
-sendFeedback() {
+sendFeedback(){
         if [ -z "$QUIET" ]; then
                 printf '%s\n' "$1"; notify-send "$1"
         fi
 }
 
-setWallpaper() {
+setWallpaper(){
         if [ "$(printenv XDG_SESSION_TYPE)" = wayland ]; then
                 swaybg --image "$1" &
         elif [ "$(printenv XDG_SESSION_TYPE)" = x11 ]; then
@@ -37,7 +37,7 @@ setWallpaper() {
         fi
 }
 
-randomWallpaper() {
+randomWallpaper(){
         WALLPAPER="$(\
                 find "$WALLPAPERS_DIR" -type f -not -path '*/\.git/*' |
                 shuf -n 1
@@ -49,7 +49,7 @@ randomWallpaper() {
         fi
 }
 
-selectWallpaper() {
+selectWallpaper(){
         WALLPAPER="$(\
                 find "$WALLPAPERS_DIR" -type f -not -path '*/\.git/*' -exec basename {} \; |
                 sed "s/\.png$//;s/\.jpg$//;s/\.jpeg$//;" |

--- a/Home/.local/bin/yadm-sync.sh
+++ b/Home/.local/bin/yadm-sync.sh
@@ -18,7 +18,7 @@ error(){ printf '%b==> ERROR:\e[0m %b%s%b\n' "${BLD}${RED}" "${BLD}" "$*" "${DEF
 die(){ error "$*"; exit 1; }
 
 # Determine repository directory
-get_repo_dir() {
+get_repo_dir(){
   if yadm rev-parse --show-toplevel &>/dev/null; then
     yadm rev-parse --show-toplevel
   elif [[ -d "${HOME}/.local/share/yadm/repo.git" ]]; then
@@ -29,7 +29,7 @@ get_repo_dir() {
 }
 
 # Show usage
-usage() {
+usage(){
   cat <<EOF
 ${BLD}yadm-sync${DEF} - Sync dotfiles between ~/ and repository
 
@@ -66,7 +66,7 @@ EOF
 }
 
 # Sync from repo to home (deploy)
-sync_pull() {
+sync_pull(){
   local repo_dir home_dir dry_run="${1:-0}"
 
   repo_dir="$(get_repo_dir)"
@@ -93,7 +93,7 @@ sync_pull() {
 }
 
 # Sync from home to repo (update repo)
-sync_push() {
+sync_push(){
   local repo_dir home_dir dry_run="${1:-0}"
 
   repo_dir="$(get_repo_dir)"
@@ -185,7 +185,7 @@ EXCLUDES
 }
 
 # Show sync status
-sync_status() {
+sync_status(){
   local repo_dir home_dir
 
   repo_dir="$(get_repo_dir)"
@@ -204,7 +204,7 @@ sync_status() {
 }
 
 # Show detailed diff
-sync_diff() {
+sync_diff(){
   local repo_dir home_dir
 
   repo_dir="$(get_repo_dir)"
@@ -226,19 +226,19 @@ sync_diff() {
         echo ""
         echo "${BLD}${BLU}Differences in:${DEF} ${rel_path}"
         echo "${BLD}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${DEF}"
-        diff -u --color=always "$file" "$source_file" 2>/dev/null || true
+        diff -u --color=always "$file" "$source_file" 2>/dev/null || :
       fi
     fi
   done < <(find "$home_dir" -type f -print0 2>/dev/null)
 }
 
 # Main
-main() {
+main(){
   local command="${1:-}"
   local dry_run=0
 
   # Parse options
-  shift || true
+  shift || :
   while [[ $# -gt 0 ]]; do
     case "$1" in
       -h|--help) usage; exit 0 ;;


### PR DESCRIPTION
- Changed all function declarations from "() {" to "(){"
- Replaced ">/dev/null 2>&1" with "&>/dev/null" bashism
- Replaced "|| true" with "|| :" bashism for better performance
- Applied standardizations to all bash scripts in Home/.local/bin/

Modified files:
- autostart.sh
- doasedit.sh
- fmenu.sh
- fzpacman.sh
- opt-pdf.sh
- search.sh
- shopt.sh
- transcode.sh
- wp.sh
- yadm-sync.sh

These changes improve code consistency and make the scripts more concise by using bash-specific features where appropriate.