### PR TITLE
fix(obs-theme): improve accessibility and fix typo in Catppuccin theme

### DIFF
--- a/Home/.config/obs-studio/themes/Catppuccin.obt
+++ b/Home/.config/obs-studio/themes/Catppuccin.obt
@@ -80,8 +80,8 @@
     --spacing_base_value: 4; /* TODO: Min 2, Max 7, Step 1 */
     --padding_base_value: 4; /* TODO: Min 0.25, Max 10, Step 2 */
 
-    --border_highlight: "transparent"; /* TODO: Better Accessibility focus state */
-    /* TODO: Move Accessibilty Colors to Theme config system */
+    --border_highlight: var(--ctp_blue);
+    /* TODO: Move Accessibility Colors to Theme config system */
 
     /* OS Fixes */
     --os_mac_font_base_value: 12;


### PR DESCRIPTION
- Changed border_highlight from transparent to ctp_blue for better focus visibility
- Fixed typo: "Accessibilty" -> "Accessibility" in TODO comment