### PR TITLE
Integrate x-cmd toolkit into shell configurations

### DIFF
--- a/Home/.config/bash/plugins/02-tools.bash
+++ b/Home/.config/bash/plugins/02-tools.bash
@@ -29,6 +29,10 @@ has thefuck && eval "$(thefuck --alias)" || :
 has pay-respects && eval "$(pay-respects bash)" || :
 has ast-grep && eval "$(ast-grep completions bash)" || :
 
+# --- x-cmd (command-line toolkit)
+# https://github.com/x-cmd/x-cmd
+ifsource "$HOME/.x-cmd.root/X"
+
 alias startintent="adb devices | tail -n +2 | cut -sf 1 | xargs -I X adb -s X shell am start $1"
 alias apkinstall="adb devices | tail -n +2 | cut -sf 1 | xargs -I X adb -s X install -r $1"
 alias rmapp="adb devices | tail -n +2 | cut -sf 1 | xargs -I X adb -s X uninstall $1"

--- a/Home/.config/fish/conf.d/tools.fish
+++ b/Home/.config/fish/conf.d/tools.fish
@@ -28,6 +28,10 @@ type -q ast-grep && ast-grep completions fish | source
 command -q cod && _evalcache cod init $fish_pid fish >/dev/null 2>&1
 command -q fixit && _evalcache fixit init fish
 
+# x-cmd (command-line toolkit)
+# https://github.com/x-cmd/x-cmd
+test -r "$HOME/.x-cmd.root/X.fish" && source "$HOME/.x-cmd.root/X.fish"
+
 if command -q starship
 	starship init fish | source >/dev/null 2>&1
 end

--- a/TODO.md
+++ b/TODO.md
@@ -1,5 +1,4 @@
 TODO:
-integrate "https://github.com/x-cmd/x-cmd" somewhere
 
 **Quick web server serving current dir**
 ```bash


### PR DESCRIPTION
Added x-cmd initialization to bash and fish shell configurations. The toolkit is now sourced if available at ~/.x-cmd.root/X for bash and ~/.x-cmd.root/X.fish for fish shell.

Resolves TODO item to integrate https://github.com/x-cmd/x-cmd