### PR TITLE
Implement etc/ and usr/ folder management in setup.sh and yadm config

### DIFF
--- a/Home/.config/yadm/bootstrap
+++ b/Home/.config/yadm/bootstrap
@@ -111,10 +111,15 @@ deploy_system_configs() {
     return 0
   fi
   info "Deploying system configurations with tuckr..."
+  local hooks_file="${REPO_DIR}/hooks.toml"
   for pkg in etc usr; do
     if [[ -d "${REPO_DIR}/${pkg}" ]]; then
       info "Linking $pkg/ → /"
-      sudo tuckr link -d "$REPO_DIR" -t / "$pkg" || warn "Failed to link $pkg"
+      if [[ -f "$hooks_file" ]]; then
+        sudo tuckr link -d "$REPO_DIR" -t / -H "$hooks_file" "$pkg" || warn "Failed to link $pkg"
+      else
+        sudo tuckr link -d "$REPO_DIR" -t / "$pkg" || warn "Failed to link $pkg"
+      fi
     else
       warn "Directory not found: ${REPO_DIR}/${pkg}"
     fi

--- a/Home/.config/yadm/config
+++ b/Home/.config/yadm/config
@@ -1,4 +1,16 @@
 # YADM Repository Configuration
+#
+# Repository Structure:
+# ├── Home/     → User dotfiles deployed to ~/ (via rsync in bootstrap)
+# ├── etc/      → System configs deployed to /etc (via tuckr)
+# ├── usr/      → System configs deployed to /usr (via tuckr)
+# └── vendor/   → Third-party dependencies
+#
+# Deployment:
+# • User configs: yadm bootstrap copies Home/ → ~/
+# • System configs: tuckr links etc/ → /etc and usr/ → /usr
+# • Run 'sudo tuckr link -d ~/.local/share/yadm/repo.git -t / etc usr'
+#
 [user]
 	# User-specific git config will be inherited from system/user git config
 [core]
@@ -13,6 +25,7 @@
 [yadm]
 	# Use the Home/ subdirectory for user dotfiles
 	# Note: This is managed via bootstrap script deployment
+	# System directories (etc/, usr/) are managed by tuckr, not yadm
 	# Automatically manage git alternates
 	auto-alt = true
 	# Auto-exclude specific patterns

--- a/hooks.toml
+++ b/hooks.toml
@@ -1,0 +1,42 @@
+# Tuckr Hooks Configuration
+# This file defines hooks for deploying system-wide configurations
+# Documentation: https://github.com/RaphGL/Tuckr
+
+# Hooks for the 'etc' package (system configuration files)
+[etc]
+# Pre-link hook: Run before linking etc/ to /etc
+# Useful for backing up existing configs or validating permissions
+# pre = """
+# echo "Preparing to link etc/ configurations..."
+# """
+
+# Post-link hook: Run after successfully linking etc/ to /etc
+# Useful for reloading services or validating deployments
+post = """
+echo "✓ System configurations (etc/) linked successfully"
+echo "  Some services may need to be restarted to apply changes"
+"""
+
+# Hooks for the 'usr' package (system libraries and binaries)
+[usr]
+# Post-link hook: Run after successfully linking usr/ to /usr
+post = """
+echo "✓ System libraries (usr/) linked successfully"
+# Reload systemd if systemd configs were modified
+if systemctl --version &>/dev/null; then
+  echo "  Reloading systemd daemon..."
+  systemctl daemon-reload 2>/dev/null || true
+fi
+"""
+
+# Global hooks (run for all packages)
+[hooks]
+# Pre-link: Runs before any package is linked
+# pre = """
+# echo "Starting tuckr deployment..."
+# """
+
+# Post-link: Runs after all packages are linked
+# post = """
+# echo "✓ All packages deployed successfully"
+# """

--- a/setup.sh
+++ b/setup.sh
@@ -213,13 +213,20 @@ tuckr_system_configs() {
 	[[ -d "$TUCKR_DIR" ]] || die "Dotfiles directory not found at $TUCKR_DIR."
 
 	local tuckr_pkgs=(etc usr)
+	local hooks_file="${TUCKR_DIR}/hooks.toml"
+
 	for pkg in "${tuckr_pkgs[@]}"; do
 		if [[ -d "${TUCKR_DIR}/${pkg}" ]]; then
 			if [[ "$DRY_RUN" == true ]]; then
 				info "[DRY-RUN] Would link '${pkg}' to target '/'"
+				[[ -f "$hooks_file" ]] && info "[DRY-RUN] Would use hooks from: $hooks_file"
 			else
 				info "Linking '${pkg}' to target '/'..."
-				sudo tuckr link -d "$TUCKR_DIR" -t / "$pkg" || warn "Failed to link ${pkg}"
+				if [[ -f "$hooks_file" ]]; then
+					sudo tuckr link -d "$TUCKR_DIR" -t / -H "$hooks_file" "$pkg" || warn "Failed to link ${pkg}"
+				else
+					sudo tuckr link -d "$TUCKR_DIR" -t / "$pkg" || warn "Failed to link ${pkg}"
+				fi
 			fi
 		else
 			warn "tuckr package '${pkg}' not found in repo, skipping."


### PR DESCRIPTION
This commit enhances the dotfiles repository to properly handle system-wide configuration directories (etc/ and usr/) using tuckr.

Changes:
- Added comprehensive documentation to yadm config explaining repository structure
- Created hooks.toml for tuckr with post-deployment hooks for etc/ and usr/
- Updated setup.sh to use hooks.toml when linking system configs
- Updated yadm bootstrap to use hooks.toml when deploying system configs
- Added systemd daemon-reload hook for usr/ package deployment

Repository Structure:
- Home/  → User dotfiles deployed to ~/ (via rsync)
- etc/   → System configs deployed to /etc (via tuckr)
- usr/   → System configs deployed to /usr (via tuckr)
- vendor/ → Third-party dependencies

The implementation ensures proper separation between user-level and system-level configurations while maintaining a single git repository for all dotfiles.