### PR TITLE
Fix FIXME comment in ccache cleaner config

### DIFF
--- a/Home/.config/bleachbit/cleaners/ccache.xml
+++ b/Home/.config/bleachbit/cleaners/ccache.xml
@@ -23,7 +23,7 @@
 
 -->
 <cleaner id="ccache" os="linux">
-	<!-- FIXME: Does it work under Windows? -->
+	<!-- Linux-specific: ccache uses different paths on Windows (~/.ccache/ vs %LOCALAPPDATA%\ccache) -->
 	<label>ccache</label>
 	<description>Cache result of files compiled by C/C++ compilers</description>
 	<option id="ccache">


### PR DESCRIPTION
Replace unclear FIXME about Windows support with explicit documentation that ccache uses platform-specific paths (Linux: ~/.ccache/ vs Windows: %LOCALAPPDATA%\ccache)