### PR TITLE
refactor: standardize function formatting across all bash scripts

### DIFF
--- a/Home/.config/bash/completer.sh
+++ b/Home/.config/bash/completer.sh
@@ -3,7 +3,7 @@
 
 #=============================== [Completions] ================================
 # Lazy-load completion function
-load_completion() {
+load_completion(){
   local name="$1" cmd="$2" kind="$3" src="$4"
   has "$cmd" || return
   declare -F "$name" &> /dev/null && return
@@ -28,7 +28,7 @@ fi
 
 # --- Editor FZF Completion
 if has fzf; then
-  _editor_completion() {
+  _editor_completion(){
     bind '"\e[0n": redraw-current-line' &> /dev/null
     local selected
     if selected=$(compgen -f -- "${COMP_WORDS[COMP_CWORD]}" | fzf --prompt='❯ ' \

--- a/Home/.local/bin/cht.sh
+++ b/Home/.local/bin/cht.sh
@@ -4,18 +4,15 @@ shopt -s nullglob globstar
 IFS=$'\n\t'
 export LC_ALL=C LANG=C
 
-has() { command -v "$1" &> /dev/null; }
-die() {
-  printf 'Error: %s\n' "$*" >&2
-  exit 1
-}
+has(){ command -v "$1" &> /dev/null; }
+die(){ printf 'Error: %s\n' "$*" >&2; exit 1; }
 
 # Tool detection
 for c in curl wget2 wget; do has "$c" && HTTP="$c" && break; done
 [[ -z ${HTTP:-} ]] && die "curl/wget required"
 for f in sk fzf; do has "$f" && FZF="$f" && break; done
 [[ -z ${FZF:-} ]] && die "sk/fzf required"
-get() {
+get(){
   case "$HTTP" in
     curl) curl -fsL "$@" ;;
     wget*) "$HTTP" -qO- "$@" ;;
@@ -23,12 +20,12 @@ get() {
 }
 readonly CHT_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/cht_list"
 readonly CHT_URL="cheat.sh"
-cache() {
+cache(){
   [[ -f $CHT_CACHE && -n "$(find "$CHT_CACHE" -mtime -7 2> /dev/null)" ]] && return 0
   mkdir -p "${CHT_CACHE%/*}"
   get "${CHT_URL}/:list" > "$CHT_CACHE" || die "Failed to fetch list"
 }
-browse() {
+browse(){
   local sel q qlist url
   cache
   sel=$("$FZF" --ansi --reverse --cycle --prompt='cht> ' \
@@ -48,7 +45,7 @@ browse() {
   printf '\n→ %s\n\n' "$url"
   get "$url"
 }
-query() {
+query(){
   local lang="${1:-}" topic="${2:-}" flags="" url
   [[ -z $lang ]] && die "Language/topic required"
   [[ ${search:-0} -eq 1 ]] && lang="~${lang}" && topic="~${topic}"
@@ -60,7 +57,7 @@ query() {
   get "$url"
 }
 
-usage() {
+usage(){
   cat << 'EOF'
 cht - cheat.sh TUI with fuzzy search
 

--- a/Home/.local/bin/doasedit.sh
+++ b/Home/.local/bin/doasedit.sh
@@ -2,7 +2,7 @@
 LC_ALL=C LANG=C
 
 # https://codeberg.org/TotallyLeGIT/doasedit/
-help() {
+help(){
   cat - >&2 << EOF
 doasedit - edit files as root using an unprivileged editor
 
@@ -17,7 +17,7 @@ EOF
 # Checks for syntax errors in doas' config
 # check_doas_conf <target> <tmp_target>
 
-check_doas_conf() {
+check_doas_conf(){
   if printf '%s' "${1}" | grep -q '^/etc/doas\(\.d/.*\)\?\.conf$'; then
     while ! doas -C "${2}"; do
       printf "doasedit: Replacing '%s' would " "$file"
@@ -33,13 +33,9 @@ check_doas_conf() {
   fi
   return 0
 }
-error() { printf 'doasedit: %s\n' "${@}" 1>&2; }
-has() { command -v "$1" &> /dev/null; }
-_exit() {
-  rm -rf "$tmpdir"
-  trap - EXIT HUP QUIT TERM INT ABRT
-  exit "${1:-0}"
-}
+error(){ printf 'doasedit: %s\n' "${@}" 1>&2; }
+has(){ command -v "$1" &> /dev/null; }
+_exit(){ rm -rf "$tmpdir"; trap - EXIT HUP QUIT TERM INT ABRT; exit "${1:-0}"; }
 # no argument passed
 [[ "${#}" -eq 0 ]] && help && exit 1
 while [[ "${#}" -ne 0 ]]; do

--- a/Home/.local/bin/dosudo.sh
+++ b/Home/.local/bin/dosudo.sh
@@ -2,7 +2,7 @@
 set -u
 # from https://github.com/Enovale/doas-sudo-shim
 
-help() {
+help(){
   cat <<- EOF
 		Usage:
 		 sudo (-i | -k | -v | -s) [-n] [-u <user>] [<command> [--] [<args>...]]
@@ -63,9 +63,9 @@ if [[ -n "$flag_i" && -n "$flag_s" ]]; then
   echo "sudo: you may not specify both the '-i' and '-s' options" >&2
   exit 1
 fi
-has() { command -v "$1" &> /dev/null; }
-_doas() { exec doas "$flag_n" "${user:+-u "$user"}" "$@"; }
-user_shell() {
+has(){ command -v "$1" &> /dev/null; }
+_doas(){ exec doas "$flag_n" "${user:+-u "$user"}" "$@"; }
+user_shell(){
   if has getent; then
     getent passwd "${user:-root}" | awk -F: 'END {print $NF ? $NF : "sh"}'
   else

--- a/Home/.local/bin/ffwrap.sh
+++ b/Home/.local/bin/ffwrap.sh
@@ -5,10 +5,10 @@ shopt -s nullglob globstar
 IFS=$'\n\t'
 export LC_ALL=C LANG=C
 
-has() { command -v "$1" &>/dev/null; }
+has(){ command -v "$1" &>/dev/null; }
 
 # Usage: ffwrap [ffmpeg_args...]
-ffwrap() {
+ffwrap(){
   local ffbin
   if has ffzap; then
     ffbin=ffzap

--- a/Home/.local/bin/fzf-prev.sh
+++ b/Home/.local/bin/fzf-prev.sh
@@ -10,26 +10,26 @@ export LC_ALL=C LANG=C
 #   FZF_PREVIEW_IMAGE_HANDLER=kitty|ueberzug|sixel|symbols (default auto)
 #   BAT_STYLE (e.g. "numbers,changes")
 
-have() { command -v "$1" &>/dev/null; }
-batcmd() { if have batcat; then printf '%s' batcat; elif have bat; then printf '%s' bat; else printf '%s' cat; fi; }
+have(){ command -v "$1" &>/dev/null; }
+batcmd(){ if have batcat; then printf '%s' batcat; elif have bat; then printf '%s' bat; else printf '%s' cat; fi; }
 
 cache_dir="${XDG_CACHE_HOME:-$HOME/.cache}/fzf"
 mkdir -p "$cache_dir" || :
 
 ueberzug_fifo="${cache_dir}/ueberzug-${PPID:-$$}.fifo"
 
-mime_of() { file --mime-type -b -- "$1"; }
-ext_of() {
+mime_of(){ file --mime-type -b -- "$1"; }
+ext_of(){
   local b="${1##*/}"
   b="${b##*.}"
   printf '%s' "${b,,}"
 }
-abspath() { readlink -f -- "$1"; }
-sha256_of() { sha256sum <<<"$1" | awk '{print $1}'; }
+abspath(){ readlink -f -- "$1"; }
+sha256_of(){ sha256sum <<<"$1" | awk '{print $1}'; }
 
 dim_cols="${FZF_PREVIEW_COLUMNS:-}"
 dim_lines="${FZF_PREVIEW_LINES:-}"
-term_dim() {
+term_dim(){
   local cols="$dim_cols" lines="$dim_lines"
   if [[ -z $cols || -z $lines ]]; then
     read -r lines cols < <(stty size </dev/tty 2>/dev/null || printf '40 120\n')
@@ -43,7 +43,7 @@ term_dim() {
   printf '%sx%s' "$cols" "$lines"
 }
 
-get_file_size() {
+get_file_size(){
   if stat --version &>/dev/null; then
     stat -c%s "$1"
   else
@@ -51,7 +51,7 @@ get_file_size() {
   fi
 }
 
-get_cache_key() {
+get_cache_key(){
   local f="$1" mtime size
   if [[ $OSTYPE == darwin* ]]; then
     mtime="$(stat -f '%m' "$f")"
@@ -63,7 +63,7 @@ get_cache_key() {
   printf '%s_%s' "$mtime" "$size"
 }
 
-get_cached_image() {
+get_cached_image(){
   local f="$1" key cache_file
   key="$(get_cache_key "$f")"
   cache_file="${cache_dir}/img-${key}.jpg"
@@ -72,7 +72,7 @@ get_cached_image() {
   printf '%s' "$cache_file"
 }
 
-cache_image() {
+cache_image(){
   local src="$1" f="$2" key cache_file
   key="$(get_cache_key "$f")"
   cache_file="${cache_dir}/img-${key}.jpg"
@@ -80,7 +80,7 @@ cache_image() {
   printf '%s' "$cache_file"
 }
 
-cmd_e() {
+cmd_e(){
   if "$@" 2>/dev/null; then
     return 0
   else
@@ -94,7 +94,7 @@ cmd_e() {
   fi
 }
 
-preview_text() {
+preview_text(){
   local file="$1" center="${2:-0}" ext
   ext="$(ext_of "$file")"
   case "$ext" in
@@ -136,7 +136,7 @@ preview_text() {
   fi
 }
 
-preview_symlink() {
+preview_symlink(){
   local loc="$1" target
   target="$(readlink -- "$loc" || printf '')"
   [[ -z $target ]] && {
@@ -146,7 +146,7 @@ preview_symlink() {
   printf 'symlink → %s\n' "$target"
 }
 
-init_ueberzug() {
+init_ueberzug(){
   [[ -p $ueberzug_fifo ]] && return 0
   rm -f "$ueberzug_fifo" 2>/dev/null || :
   mkfifo "$ueberzug_fifo" || return 1
@@ -160,13 +160,13 @@ init_ueberzug() {
   fi
 }
 
-cleanup_ueberzug() {
+cleanup_ueberzug(){
   [[ -p $ueberzug_fifo ]] || return 0
   printf '{"action": "remove", "identifier": "fzf"}\n' >>"$ueberzug_fifo" 2>/dev/null || :
   rm -f "$ueberzug_fifo" 2>/dev/null || :
 }
 
-preview_image_backend() {
+preview_image_backend(){
   local img="$1" dim
   dim="$(term_dim)"
   local handler="${FZF_PREVIEW_IMAGE_HANDLER:-auto}"
@@ -202,7 +202,7 @@ preview_image_backend() {
   file --brief --dereference --mime -- "$img"
 }
 
-preview_archive() {
+preview_archive(){
   local f="$1" ext size max_size=$((100 * 1024 * 1024))
   ext="$(ext_of "$f")"
   size="$(get_file_size "$f" 2>/dev/null || printf '0')"
@@ -280,7 +280,7 @@ preview_archive() {
   file --brief --dereference --mime -- "$f"
 }
 
-preview_misc_by_ext() {
+preview_misc_by_ext(){
   local f="$1" ext
   ext="$(ext_of "$f")"
   case "$ext" in
@@ -376,7 +376,7 @@ preview_misc_by_ext() {
   file --brief --dereference --mime -- "$f"
 }
 
-preview_file() {
+preview_file(){
   local loc="$1" center="${2:-0}" mime tmp_img cached_img
   tmp_img="${cache_dir}/tmp-${PPID:-$$}. jpg"
   FILE="$loc"
@@ -519,7 +519,7 @@ preview_file() {
   rm -f "$tmp_img" "${tmp_img}.jpg" 2>/dev/null || :
 }
 
-parse_arg() {
+parse_arg(){
   local in="$1" file="$1" center=0
   if [[ !  -r $file ]]; then
     if [[ $file =~ ^(. +):([0-9]+)\ *$ ]] && [[ -r ${BASH_REMATCH[1]} ]]; then
@@ -533,9 +533,9 @@ parse_arg() {
   printf '%s\n%s\n' "${file/#\~\//$HOME/}" "$center"
 }
 
-usage() { printf 'usage: %s preview <PATH|PATH:LINE>\n' "${0##*/}"; }
+usage(){ printf 'usage: %s preview <PATH|PATH:LINE>\n' "${0##*/}"; }
 
-cmd_preview() {
+cmd_preview(){
   [[ $# -ge 1 ]] || {
     usage
     return 1
@@ -549,14 +549,14 @@ cmd_preview() {
   preview_file "$file" "$center"
 }
 
-cleanup() {
+cleanup(){
   cleanup_ueberzug
   ls -1t "$cache_dir" 2>/dev/null | tail -n +201 | while IFS= read -r f; do rm -f "${cache_dir}/$f"; done || :
 }
 
 trap cleanup HUP INT TERM QUIT EXIT
 
-main() {
+main(){
   local cmd="${1:-}"
   shift || :
   case "${cmd:-}" in

--- a/Home/.local/bin/fzgit.sh
+++ b/Home/.local/bin/fzgit.sh
@@ -12,18 +12,15 @@ readonly LBLU=$'\e[38;5;117m' PNK=$'\e[38;5;218m' BWHT=$'\e[97m'
 readonly DEF=$'\e[0m' BLD=$'\e[1m' UL=$'\e[4m'
 
 # Core helpers
-has() { command -v "$1" &> /dev/null; }
-err() { printf '%b[ERR]%b %s\n' "$RED" "$DEF" "$*" >&2; }
-die() {
-  err "$@"
-  exit 1
-}
+has(){ command -v "$1" &> /dev/null; }
+err(){ printf '%b[ERR]%b %s\n' "$RED" "$DEF" "$*" >&2; }
+die(){ err "$@"; exit 1; }
 
 # Version
-_ver() { printf '%b%s%b -- %bv1.0.0%b fuzzy git TUI (gix/gh/forgit)\n' "$BLD" "${0##*/}" "$DEF" "$UL" "$DEF"; }
+_ver(){ printf '%b%s%b -- %bv1.0.0%b fuzzy git TUI (gix/gh/forgit)\n' "$BLD" "${0##*/}" "$DEF" "$UL" "$DEF"; }
 
 # Help
-_help() {
+_help(){
   cat << EOF
 ${BLD}USAGE${DEF}  ${0##*/} ${UL}CMD${DEF} [${UL}ARGS${DEF}]
 
@@ -108,7 +105,7 @@ else
 fi
 
 # Git wrapper (prefers gix)
-_git() {
+_git(){
   if [[ ${GIT##*/} == gix ]]; then
     case "$1" in
       log) gix log "$@" ;;
@@ -122,12 +119,12 @@ _git() {
 }
 
 # Check if in git repo
-_check_repo() {
+_check_repo(){
   _git rev-parse --git-dir &> /dev/null || die "Not a git repository"
 }
 
 # FZF wrapper with defaults
-_fzf() {
+_fzf(){
   local -a opts=(
     --ansi --cycle --no-mouse --reverse --inline-info
     --color='pointer:green,marker:green'
@@ -176,13 +173,13 @@ _fzf() {
 }
 
 # Copy to clipboard
-_copy() {
+_copy(){
   [[ -z ${CLIP} ]] && return 0
   printf '%s' "$1" | "$CLIP"
 }
 
 # Get pager (delta > bat > less > cat)
-_pager() {
+_pager(){
   if [[ -n ${DELTA} ]]; then
     printf '%s' "${DELTA} --paging=never --side-by-side"
   elif [[ -n ${BAT} ]]; then
@@ -193,12 +190,12 @@ _pager() {
 }
 
 # Extract hash from fzf selection
-_extract_hash() {
+_extract_hash(){
   grep -Eo '[a-f0-9]{7,40}' | head -1
 }
 
 # Interactive git add
-_add() {
+_add(){
   _check_repo
   local pager=$(_pager)
   local files
@@ -214,7 +211,7 @@ _add() {
 }
 
 # Interactive git diff
-_diff() {
+_diff(){
   _check_repo
   local pager=$(_pager)
   local target=${1:-HEAD}
@@ -229,7 +226,7 @@ _diff() {
 }
 
 # Interactive git log
-_log() {
+_log(){
   _check_repo
   local pager=$(_pager)
   local format='%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset'
@@ -246,7 +243,7 @@ _log() {
 }
 
 # Interactive git show
-_show() {
+_show(){
   _check_repo
   local pager=$(_pager)
   local format='%C(auto)%h%d %s %C(black)%C(bold)%cr%Creset'
@@ -260,7 +257,7 @@ _show() {
 }
 
 # Interactive git status
-_status() {
+_status(){
   _check_repo
   local pager=$(_pager)
 
@@ -274,7 +271,7 @@ _status() {
 }
 
 # Interactive branch checkout
-_branch() {
+_branch(){
   _check_repo
   local branch
   branch=$(_git branch --all --color=always --sort=-committerdate "$@" \
@@ -290,7 +287,7 @@ _branch() {
 }
 
 # Interactive branch delete
-_branch_delete() {
+_branch_delete(){
   _check_repo
   local branches
   branches=$(_git branch --color=always --sort=-committerdate "$@" \
@@ -306,7 +303,7 @@ _branch_delete() {
 }
 
 # Interactive tag checkout
-_tag() {
+_tag(){
   _check_repo
   local tag
   tag=$(_git tag --sort=-version:refname | _fzf \
@@ -320,7 +317,7 @@ _tag() {
 }
 
 # Interactive commit checkout
-_commit() {
+_commit(){
   _check_repo
   local hash
   hash=$(_show "$@")
@@ -329,7 +326,7 @@ _commit() {
 }
 
 # Interactive revert
-_revert() {
+_revert(){
   _check_repo
   local hash
   hash=$(_show "$@")
@@ -338,7 +335,7 @@ _revert() {
 }
 
 # Interactive reset HEAD
-_reset() {
+_reset(){
   _check_repo
   local pager=$(_pager)
   local files
@@ -353,7 +350,7 @@ _reset() {
 }
 
 # Interactive file checkout
-_file() {
+_file(){
   _check_repo
   local pager=$(_pager)
   local files
@@ -368,7 +365,7 @@ _file() {
 }
 
 # Interactive stash viewer
-_stash() {
+_stash(){
   _check_repo
   local pager=$(_pager)
   local stash
@@ -385,7 +382,7 @@ _stash() {
 }
 
 # Interactive stash push
-_stash_push() {
+_stash_push(){
   _check_repo
   local pager=$(_pager)
   local files
@@ -399,7 +396,7 @@ _stash_push() {
 }
 
 # Interactive git clean
-_clean() {
+_clean(){
   _check_repo
   local files
   files=$(_git clean -xdffn | sed 's/^Would remove //' | _fzf -m \
@@ -416,7 +413,7 @@ _clean() {
 }
 
 # Interactive cherry-pick
-_cherry() {
+_cherry(){
   _check_repo
   local hash
   hash=$(_show "$@")
@@ -425,7 +422,7 @@ _cherry() {
 }
 
 # Interactive rebase
-_rebase() {
+_rebase(){
   _check_repo
   local hash
   hash=$(_show "$@")
@@ -434,7 +431,7 @@ _rebase() {
 }
 
 # Interactive reflog
-_reflog() {
+_reflog(){
   _check_repo
   local pager=$(_pager)
 
@@ -448,7 +445,7 @@ _reflog() {
 }
 
 # Interactive blame
-_blame() {
+_blame(){
   _check_repo
   [[ -z $1 ]] && die "Usage: ${0##*/} blame <file>"
   local pager=$(_pager)
@@ -463,7 +460,7 @@ _blame() {
 }
 
 # Interactive fixup commit
-_fixup() {
+_fixup(){
   _check_repo
   local hash
   hash=$(_show "$@")
@@ -473,7 +470,7 @@ _fixup() {
 }
 
 # Interactive squash commit
-_squash() {
+_squash(){
   _check_repo
   local hash
   hash=$(_show "$@")
@@ -483,7 +480,7 @@ _squash() {
 }
 
 # Interactive difftool
-_difftool() {
+_difftool(){
   _check_repo
   local files
   files=$(_diff "$@")
@@ -492,7 +489,7 @@ _difftool() {
 }
 
 # GitHub PR viewer (requires gh)
-_pr() {
+_pr(){
   [[ -z ${GH} ]] && die "gh (GitHub CLI) not found"
   _check_repo
 
@@ -507,7 +504,7 @@ _pr() {
 }
 
 # GitHub issue viewer (requires gh)
-_issue() {
+_issue(){
   [[ -z ${GH} ]] && die "gh (GitHub CLI) not found"
   _check_repo
 
@@ -521,7 +518,7 @@ _issue() {
 }
 
 # GitHub workflow run viewer (requires gh)
-_run() {
+_run(){
   [[ -z ${GH} ]] && die "gh (GitHub CLI) not found"
   _check_repo
 
@@ -535,7 +532,7 @@ _run() {
 }
 
 # GitHub repo browser (requires gh)
-_repo() {
+_repo(){
   [[ -z ${GH} ]] && die "gh (GitHub CLI) not found"
 
   gh repo list --color=always | _fzf \
@@ -549,7 +546,7 @@ _repo() {
 }
 
 # Generate .gitignore (gitignore.io)
-_ignore() {
+_ignore(){
   local api="https://www.toptal.com/developers/gitignore/api"
   local list
 
@@ -568,7 +565,7 @@ _ignore() {
 }
 
 # Interactive clone from GitHub (requires gh)
-_clone() {
+_clone(){
   [[ -z ${GH} ]] && die "gh (GitHub CLI) not found"
 
   local repo

--- a/Home/.local/bin/gh-get-asset.sh
+++ b/Home/.local/bin/gh-get-asset.sh
@@ -17,7 +17,7 @@ release=""
 output_opt=(-O)
 curl_args=(-fsSL)
 
-usage() {
+usage(){
   cat << 'EOF'
 gh-get-asset - Download GitHub release assets
 
@@ -52,7 +52,7 @@ AUTHOR:
 EOF
 }
 
-gh_get_release() {
+gh_get_release(){
   local repo="$1" substring="$2"
 
   curl -fsSL -o "$TMP" "https://api.github.com/repos/${repo}/releases"
@@ -65,7 +65,7 @@ gh_get_release() {
   "$JQ" -rM "${selector}.assets[]|select(.name| contains(\"${substring}\"))? | .browser_download_url" < "$TMP"
 }
 
-main() { # Parse options
+main(){ # Parse options
   while getopts "r:so:h" opt; do
     case "$opt" in
       r) release="$OPTARG" ;;

--- a/Home/.local/bin/gh-maint.sh
+++ b/Home/.local/bin/gh-maint.sh
@@ -10,17 +10,14 @@ VERBOSE=false
 MODE="${MODE:-both}"
 DELETED_BRANCHES=0
 DELETED_REMOTE_BRANCHES=0
-has() { command -v "$1" &> /dev/null; }
-die() {
-  printf '%s\n' "$1" >&2
-  exit 1
-}
-msg() { printf '\033[0;96m==> %s\033[0m\n' "$1"; }
-warn() { printf '\033[0;93mWARN: %s\033[0m\n' "$1"; }
-ok() { printf '\033[0;92m%s\033[0m\n' "$1"; }
-err() { printf '\033[0;31mERROR: %s\033[0m\n' "$1" >&2; }
-verbose() { [[ $VERBOSE == true ]] && printf '\033[0;90m%s\033[0m\n' "$1" || :; }
-usage() {
+has(){ command -v "$1" &> /dev/null; }
+die(){ printf '%s\n' "$1" >&2; exit 1; }
+msg(){ printf '\033[0;96m==> %s\033[0m\n' "$1"; }
+warn(){ printf '\033[0;93mWARN: %s\033[0m\n' "$1"; }
+ok(){ printf '\033[0;92m%s\033[0m\n' "$1"; }
+err(){ printf '\033[0;31mERROR: %s\033[0m\n' "$1" >&2; }
+verbose(){ [[ $VERBOSE == true ]] && printf '\033[0;90m%s\033[0m\n' "$1" || :; }
+usage(){
   cat << EOF
 Usage: $(basename "$0") [MODE] [OPTIONS]
 
@@ -96,7 +93,7 @@ else
   verbose "Using git"
 fi
 [[ -d .git ]] || die "Not a git repository"
-determine_trunk() {
+determine_trunk(){
   local trunk=
   # Use -F for literal string matching (faster)
   if git branch --list master 2> /dev/null | grep -qF master; then
@@ -108,7 +105,7 @@ determine_trunk() {
   fi
   printf '%s' "$trunk"
 }
-update_repo() {
+update_repo(){
   msg "Updating repository..."
   local trunk=$(determine_trunk)
   verbose "Trunk: $trunk"
@@ -139,7 +136,7 @@ update_repo() {
     verbose "Would update $trunk from remote and sync submodules"
   fi
 }
-clean_repo() {
+clean_repo(){
   msg "Cleaning repository..."
   local trunk
   trunk=$(determine_trunk)
@@ -240,7 +237,7 @@ clean_repo() {
   fi
   optimize_repo
 }
-check_gha_failures() {
+check_gha_failures(){
   if ! has gh; then
     warn "gh command not found, skipping GHA failure check."
     return
@@ -270,7 +267,7 @@ check_gha_failures() {
     verbose "The latest workflow run was successful."
   fi
 }
-auto_merge_pr() {
+auto_merge_pr(){
   [[ -n $PR_URL ]] || die "PR URL required for merge mode."
   local strategy="$MERGE_STRATEGY"
   local owner repo pr
@@ -345,7 +342,7 @@ auto_merge_pr() {
   git push -q origin "$head_ref"
   ok "Done. Conflicts resolved and pushed."
 }
-optimize_repo() {
+optimize_repo(){
   msg "Optimizing repository..."
   if [[ $DRY_RUN == true ]]; then
     msg "Would optimize: repack, gc, reflog, worktrees, maintenance"
@@ -374,7 +371,7 @@ optimize_repo() {
     ok "Optimization complete"
   fi
 }
-main() {
+main(){
   case $MODE in
     clean) clean_repo ;;
     update) update_repo ;;

--- a/Home/.local/bin/git-rm-submodule.sh
+++ b/Home/.local/bin/git-rm-submodule.sh
@@ -10,19 +10,16 @@ export LC_ALL=C LANG=C IFS=$'\n\t'
 readonly RED=$'\e[0;31m' GREEN=$'\e[0;32m' YELLOW=$'\e[0;33m' RESET=$'\e[0m'
 
 # Helper functions
-die() {
-  printf '%bError: %s%b\n' "$RED" "$*" "$RESET" >&2
-  exit 1
-}
-log() { printf '%s\n' "$*"; }
-ok() { printf '%b[ OK ]%b\n' "$GREEN" "$RESET"; }
-fail() { printf '%b[FAIL]%b\n' "$RED" "$RESET"; }
+die(){ printf '%bError: %s%b\n' "$RED" "$*" "$RESET" >&2; exit 1; }
+log(){ printf '%s\n' "$*"; }
+ok(){ printf '%b[ OK ]%b\n' "$GREEN" "$RESET"; }
+fail(){ printf '%b[FAIL]%b\n' "$RED" "$RESET"; }
 
 # Log file for operations
 readonly LOG_FILE=$(mktemp)
 trap 'rm -f "$LOG_FILE"' EXIT
 
-usage() {
+usage(){
   cat <<'EOF'
 git-rm-submodule - Completely remove Git submodules
 
@@ -57,12 +54,12 @@ NOTE:
 EOF
 }
 
-check_args() {
+check_args(){
   [[ ${#} -ge 1 ]] || die "Expected at least 1 argument, got ${#}"
   [[ -d ${PWD}/.git ]] || die "Not a Git repository. Run from repository root."
 }
 
-remove_git_submodule() {
+remove_git_submodule(){
   local submodule="$1"
 
   printf '  Deinitializing submodule                  '
@@ -93,14 +90,14 @@ remove_git_submodule() {
   fi
 }
 
-remove_git_submodules() {
+remove_git_submodules(){
   for module in "$@"; do
     printf '%b--- Removing module: %s ---%b\n' "$YELLOW" "$module" "$RESET"
     remove_git_submodule "$module"
   done
 }
 
-main() { # Check for help
+main(){ # Check for help
   for arg in "$@"; do
     if [[ $arg == -h || $arg == --help ]]; then
       usage

--- a/Home/.local/bin/jqwrap.sh
+++ b/Home/.local/bin/jqwrap.sh
@@ -5,10 +5,10 @@ shopt -s nullglob globstar
 IFS=$'\n\t'
 export LC_ALL=C LANG=C
 
-has() { command -v "$1" &>/dev/null; }
+has(){ command -v "$1" &>/dev/null; }
 
 # Usage: jqwrap [jq_args...]
-jqwrap() {
+jqwrap(){
   local jqbin
   if has jaq; then
     jqbin=jaq

--- a/Home/.local/bin/launcher.sh
+++ b/Home/.local/bin/launcher.sh
@@ -9,10 +9,10 @@ export LC_ALL=C LANG=C HOME="/home/${SUDO_USER:-$USER}"
 #
 # usage: launcher.sh [app|power|file]
 #        If no argument is provided, opens a mode selection menu.
-has() { command -v "$1" &> /dev/null; }
+has(){ command -v "$1" &> /dev/null; }
 # --- Menu Abstraction ---
 # Detects context and available tools to select the best menu provider.
-_menu() {
+_menu(){
   local prompt="${1:-select: }"
   # 1. Prefer fzf if running in a terminal
   if [[ -t 0 ]] && has fzf; then
@@ -34,14 +34,14 @@ _menu() {
 }
 
 # --- Confirmation Helper ---
-_confirm() {
+_confirm(){
   local ans
   ans=$(printf "No\nYes" | _menu "Confirm execute?")
   [[ $ans == "Yes" ]]
 }
 
 # --- Mode: App Launcher (merged fmenu.sh) ---
-mode_app() {
+mode_app(){
   local cmd dir file
   local -A paths
   # Iterate PATH to find executables (bash-native, avoids parsing ls)
@@ -64,7 +64,7 @@ mode_app() {
 }
 
 # --- Mode: Power Menu (merged power.sh & launcher.sh) ---
-mode_power() {
+mode_power(){
   local -a opts=("Lock" "Suspend" "Logout" "Reboot" "Power Off" "Firmware Setup")
   local action
   action=$(printf '%s\n' "${opts[@]}" | _menu "Power: ") || return 0
@@ -80,7 +80,7 @@ mode_power() {
 }
 
 # --- Mode: File Opener (from launcher.sh) ---
-mode_file() {
+mode_file(){
   local target
   # fd: fast, ignores .git, hidden files excluded by default
   target=$(fd --type f . "$HOME" 2> /dev/null | _menu "Open File: ") || return 0
@@ -89,7 +89,7 @@ mode_file() {
 }
 
 # --- Main Dispatch ---
-main() {
+main(){
   local mode="${1:-}"
   if [[ -z $mode ]]; then
     # Main menu if no argument provided

--- a/Home/.local/bin/lint-format.sh
+++ b/Home/.local/bin/lint-format.sh
@@ -32,9 +32,9 @@ TOTAL_MODIFIED=0
 TOTAL_ERRORS=0
 
 # --- Helpers ---
-has() { command -v "$1" &>/dev/null; }
+has(){ command -v "$1" &>/dev/null; }
 
-check_deps() {
+check_deps(){
   local missing=() optional=()
   local required=(shfmt shellcheck biome yamllint yamlfmt ruff markdownlint)
   local opt=(taplo mdformat stylua selene ast-grep actionlint prettier)
@@ -59,7 +59,7 @@ check_deps() {
   return 0
 }
 
-find_files() {
+find_files(){
   local ext="$1"
   if [[ $FD == "find" ]]; then
     find "$PROJECT_ROOT" -type f -name "*.$ext" \
@@ -78,14 +78,14 @@ find_files() {
   fi
 }
 
-find_files_multi() {
+find_files_multi(){
   local exts=("$@")
   for ext in "${exts[@]}"; do
     find_files "$ext"
   done | sort -u
 }
 
-record_result() {
+record_result(){
   local file="$1" group="$2" modified="$3" errors="$4"
   FILE_RESULTS["$file"]="$group|$modified|$errors"
   ((TOTAL_FILES++))
@@ -96,11 +96,11 @@ record_result() {
   }
 }
 
-add_fix_cmd() {
+add_fix_cmd(){
   FIX_COMMANDS+=("$1")
 }
 
-run_formatter() {
+run_formatter(){
   local tool="$1" desc="$2"
   shift 2
   if [[ $DRY_RUN == "true" ]]; then
@@ -111,7 +111,7 @@ run_formatter() {
   "$tool" "$@" 2>&1 || return 1
 }
 
-run_linter() {
+run_linter(){
   local tool="$1" desc="$2"
   shift 2
   log "$desc..."
@@ -119,7 +119,7 @@ run_linter() {
 }
 
 # --- YAML Processor ---
-proc_yaml() {
+proc_yaml(){
   local group="yaml" files=()
   mapfile -t files < <(find_files_multi yml yaml)
   [[ ${#files[@]} -eq 0 ]] && return 0
@@ -165,7 +165,7 @@ proc_yaml() {
 }
 
 # --- JSON/JS/TS/CSS Processor ---
-proc_web() {
+proc_web(){
   local group="web"
   log "Processing JS/TS/JSON/CSS..."
 
@@ -192,7 +192,7 @@ proc_web() {
 }
 
 # --- Shell Scripts Processor ---
-proc_shell() {
+proc_shell(){
   local group="shell" files=()
   mapfile -t files < <(find_files_multi sh bash zsh)
   [[ ${#files[@]} -eq 0 ]] && return 0
@@ -231,7 +231,7 @@ proc_shell() {
 }
 
 # --- Fish Scripts Processor ---
-proc_fish() {
+proc_fish(){
   local group="fish" files=()
   mapfile -t files < <(find_files fish)
   [[ ${#files[@]} -eq 0 ]] && return 0
@@ -252,7 +252,7 @@ proc_fish() {
 }
 
 # --- TOML Processor ---
-proc_toml() {
+proc_toml(){
   local group="toml" files=()
   mapfile -t files < <(find_files toml)
   [[ ${#files[@]} -eq 0 ]] && return 0
@@ -284,7 +284,7 @@ proc_toml() {
 }
 
 # --- Python Processor ---
-proc_python() {
+proc_python(){
   local group="python" files=()
   mapfile -t files < <(find_files py)
   [[ ${#files[@]} -eq 0 ]] && return 0
@@ -311,7 +311,7 @@ proc_python() {
 }
 
 # --- Lua Processor ---
-proc_lua() {
+proc_lua(){
   local group="lua" files=()
   mapfile -t files < <(find_files lua)
   [[ ${#files[@]} -eq 0 ]] && return 0
@@ -345,7 +345,7 @@ proc_lua() {
 }
 
 # --- Markdown Processor ---
-proc_markdown() {
+proc_markdown(){
   local group="markdown" files=()
   mapfile -t files < <(find_files md)
   [[ ${#files[@]} -eq 0 ]] && return 0
@@ -378,7 +378,7 @@ proc_markdown() {
 }
 
 # --- GitHub Actions Processor ---
-proc_actions() {
+proc_actions(){
   local group="actions" files=()
   mapfile -t files < <(find .github/workflows -type f -name "*.yml" -o -name "*.yaml" 2>/dev/null || true)
   [[ ${#files[@]} -eq 0 ]] && return 0
@@ -406,7 +406,7 @@ proc_actions() {
 }
 
 # --- XML Processor ---
-proc_xml() {
+proc_xml(){
   local group="xml" files=()
   mapfile -t files < <(find_files_multi xml svg)
   [[ ${#files[@]} -eq 0 ]] && return 0
@@ -421,7 +421,7 @@ proc_xml() {
 }
 
 # --- AST-Grep Processor ---
-proc_ast_grep() {
+proc_ast_grep(){
   local group="ast-grep"
   if ! has ast-grep; then return 0; fi
 
@@ -437,7 +437,7 @@ proc_ast_grep() {
 }
 
 # --- Report Generation ---
-print_table() {
+print_table(){
   log ""
   log "═══════════════════════════════════════════════════════════════════════════"
   log "FILE RESULTS"
@@ -455,7 +455,7 @@ print_table() {
   log "═══════════════════════════════════════════════════════════════════════════"
 }
 
-print_commands() {
+print_commands(){
   log ""
   log "FIX COMMANDS (Reproducible)"
   log "───────────────────────────────────────────────────────────────────────────"
@@ -465,7 +465,7 @@ print_commands() {
   log ""
 }
 
-print_summary() {
+print_summary(){
   log ""
   log "═══════════════════════════════════════════════════════════════════════════"
   log "SUMMARY"
@@ -490,7 +490,7 @@ print_summary() {
 }
 
 # --- Main ---
-main() {
+main(){
   log "Exhaustive Lint & Format Pipeline"
   log "Policy: 2-space indent, 120-char width, zero errors"
   log "Root: $PROJECT_ROOT"

--- a/Home/.local/bin/media-opt.sh
+++ b/Home/.local/bin/media-opt.sh
@@ -12,10 +12,10 @@ export LC_ALL=C LANG=C HOME="/home/${SUDO_USER:-$USER}"
 : "${VIDEO_CODEC:=libsvtav1}" "${AUDIO_CODEC:=libopus}" "${AUDIO_BR:=128k}"
 
 R=$'\e[31m' G=$'\e[32m' Y=$'\e[33m' B=$'\e[34m' X=$'\e[0m'
-log() { printf "${B}[%(%H:%M:%S)T]${X} %s\n" -1 "$*"; }
-err() { printf "${R}[ERR]${X} %s\n" "$*" >&2; }
-has() { command -v "$1" &> /dev/null; }
-usage() {
+log(){ printf "${B}[%(%H:%M:%S)T]${X} %s\n" -1 "$*"; }
+err(){ printf "${R}[ERR]${X} %s\n" "$*" >&2; }
+has(){ command -v "$1" &> /dev/null; }
+usage(){
   cat << EOF
 Usage: $(basename "$0") [OPTIONS] [PATH...]
 Batch Mode:
@@ -37,7 +37,7 @@ EOF
 # ==============================================================================
 # INTERACTIVE MODE (yor-mc-lite integration)
 # ==============================================================================
-interactive_mode() {
+interactive_mode(){
   has ffmpeg || {
     err "ffmpeg required for interactive mode"
     exit 1
@@ -148,7 +148,7 @@ interactive_mode() {
 # ==============================================================================
 # BATCH OPTIMIZATION
 # ==============================================================================
-opt_img() {
+opt_img(){
   local f="$1" out="$2" ext l_ext
   ext="${f##*.}"
   l_ext="${ext,,}"
@@ -179,7 +179,7 @@ opt_img() {
   fi
 }
 
-opt_svg() {
+opt_svg(){
   local f="$1" out="$2"
   if has image-optimizer; then
     tool="image-optimizer"
@@ -199,7 +199,7 @@ opt_svg() {
   fi
 }
 
-opt_vid() {
+opt_vid(){
   local f="$1" out="$2"
   local a_args=(-c:a "$AUDIO_CODEC" -b:a "$AUDIO_BR")
   [[ $AUDIO_CODEC == "copy" ]] && a_args=(-c:a copy)
@@ -219,7 +219,7 @@ opt_vid() {
   fi
 }
 
-optimize_file() {
+optimize_file(){
   local f="$1"
   [[ ! -f $f ]] && return 0
   local ext tmp tool cmd
@@ -282,7 +282,7 @@ export JOBS QUALITY LOSSLESS VIDEO_CODEC VIDEO_CRF AUDIO_CODEC AUDIO_BR DRY_RUN 
 # ==============================================================================
 # MAIN
 # ==============================================================================
-main() {
+main(){
   local -a inputs=()
   while [[ $# -gt 0 ]]; do
     case "$1" in

--- a/Home/.local/bin/media.sh
+++ b/Home/.local/bin/media.sh
@@ -9,7 +9,7 @@
 
 IFS=$'\n\t'
 
-usage() {
+usage(){
   cat << 'EOF'
 media - Media toolkit for CD burning, USB creation, and transcoding
 
@@ -50,7 +50,7 @@ PNGZIP OPTIONS:
 EOF
 }
 
-cmd_cd() {
+cmd_cd(){
   local toc="$1"
   need cdrdao
   [[ -f $toc ]] || die "TOC file not found: $toc"
@@ -59,7 +59,7 @@ cmd_cd() {
   printf '✓ CD burned successfully\n'
 }
 
-cmd_usb() {
+cmd_usb(){
   local iso="$1" dst="$2" size
   for cmd in dd pv stat; do need "$cmd"; done
   [[ -f $iso ]] || die "File not found: $iso"
@@ -81,10 +81,10 @@ cmd_usb() {
   log "✓ Copy completed!"
 }
 
-cmd_compress() { tar -czf "${1%/}.tar.gz" "${1%/}"; }
-cmd_decompress() { tar -xzf "$1"; }
+cmd_compress(){ tar -czf "${1%/}.tar.gz" "${1%/}"; }
+cmd_decompress(){ tar -xzf "$1"; }
 
-cmd_iso2sd() {
+cmd_iso2sd(){
   local iso="$1" dst="$2"
   [[ -f $iso ]] || die "File not found: $iso"
   [[ -b $dst ]] || die "Not a block device: $dst"
@@ -92,7 +92,7 @@ cmd_iso2sd() {
   sudo eject "$dst" || :
 }
 
-cmd_format() {
+cmd_format(){
   local dev="$1" name="$2"
   [[ -b $dev ]] || die "Not a block device: $dev"
   log "⚠️  WARNING: Erasing all data on $dev, label '$name'"
@@ -111,7 +111,7 @@ cmd_format() {
   info "Drive $dev formatted as exFAT, labeled '$name'"
 }
 
-cmd_ripdvd() {
+cmd_ripdvd(){
   local iso="$1" dvd="/dev/sr0"
   for cmd in isoinfo dd pv sha1sum; do need "$cmd"; done
   [[ -b $dvd ]] || die "DVD device not found: $dvd"
@@ -135,7 +135,7 @@ cmd_ripdvd() {
   log "✓ DVD ripped successfully!"
 }
 
-cmd_pngzip() {
+cmd_pngzip(){
   local GRAYSCALE=0 TOUCH=0 VERBOSE=1 DPI=0 OPTIND
   while getopts ":gqtr:h" o; do
     case $o in
@@ -197,33 +197,33 @@ cmd_pngzip() {
   done
 }
 
-cmd_vid1080() {
+cmd_vid1080(){
   local vid="$1"
   need ffmpeg
   ffmpeg -i "$vid" -vf scale=1920:1080 -c:v libx264 -preset fast -crf 23 -c:a copy "${vid%.*}"-1080p.mp4
 }
 
-cmd_vid4k() {
+cmd_vid4k(){
   local vid="$1"
   need ffmpeg
   ffmpeg -i "$vid" -c:v libx265 -preset slow -crf 24 -c:a aac -b:a 192k "${vid%.*}"-optimized.mp4
 }
 
-cmd_jpg() {
+cmd_jpg(){
   local img="$1"
   shift
   need magick
   magick "$img" "$@" -quality 95 -strip "${img%.*}"-optimized.jpg
 }
 
-cmd_jpgsmall() {
+cmd_jpgsmall(){
   local img="$1"
   shift
   need magick
   magick "$img" "$@" -resize 1080x\> -quality 95 -strip "${img%.*}"-optimized.jpg
 }
 
-cmd_png() {
+cmd_png(){
   local img="$1"
   shift
   need magick
@@ -232,7 +232,7 @@ cmd_png() {
     -define png:exclude-chunk=all "${img%.*}"-optimized.png
 }
 
-main() {
+main(){
   [[ ${#} -eq 0 || $1 == -h || $1 == --help ]] && {
     usage
     exit 0

--- a/Home/.local/bin/netinfo.sh
+++ b/Home/.local/bin/netinfo.sh
@@ -15,7 +15,7 @@ need curl
 need awk
 
 # JSON getter with jq fallback
-jget() {
+jget(){
   local json="$1" field="$2"
   if [[ -n $JQ ]]; then
     "$JQ" -r "$field" <<< "$json"
@@ -25,7 +25,7 @@ jget() {
   fi
 }
 
-speed_test() {
+speed_test(){
   local raw up
 
   printf 'Testing download speed...\n' >&2
@@ -38,7 +38,7 @@ speed_test() {
   awk -v s="$up" 'BEGIN{printf "Up:   %.2f Mbps\n",(s*8)/(1024*1024)}'
 }
 
-weather() {
+weather(){
   local location="${1:-}"
   [[ -z $location ]] && location="Bielefeld"
 
@@ -48,7 +48,7 @@ weather() {
   }
 }
 
-ip_info() {
+ip_info(){
   local json ip loc
 
   json=$(curl -fsS -H "User-Agent: ${UA}" https://ipinfo.io/json 2> /dev/null || printf '{}')
@@ -62,7 +62,7 @@ ip_info() {
   weather "$loc"
 }
 
-usage() {
+usage(){
   cat << 'EOF'
 netinfo - Network information tool
 
@@ -88,7 +88,7 @@ DEPENDENCIES:
 EOF
 }
 
-main() {
+main(){
   local cmd="${1:-all}"
   shift || :
 

--- a/Home/.local/bin/onedrive_log.sh
+++ b/Home/.local/bin/onedrive_log.sh
@@ -4,11 +4,8 @@ set -euo pipefail
 shopt -s nullglob globstar
 IFS=$'\n\t'
 export LC_ALL=C LANG=C
-has() { command -v "$1" &>/dev/null; }
-die() {
-  printf 'Error: %s\n' "$*" >&2
-  exit 1
-}
+has(){ command -v "$1" &>/dev/null; }
+die(){ printf 'Error: %s\n' "$*" >&2; exit 1; }
 
 # Check dependencies
 has journalctl || die "journalctl is required"

--- a/Home/.local/bin/open_with_vscode.sh
+++ b/Home/.local/bin/open_with_vscode.sh
@@ -4,12 +4,9 @@ shopt -s nullglob
 LC_ALL=C LANG=C
 # Open files/URIs in VS Code
 # Source: https://github.com/AhmetCanArslan/linux-scripts
-has() { command -v "$1" &>/dev/null; }
-die() {
-  printf 'Error: %s\n' "$*" >&2
-  exit 1
-}
-usage() {
+has(){ command -v "$1" &>/dev/null; }
+die(){ printf 'Error: %s\n' "$*" >&2; exit 1; }
+usage(){
   cat <<'EOF'
 open_with_vscode - Open files/URIs in VS Code
 
@@ -35,7 +32,7 @@ REQUIREMENTS:
   - code (VS Code CLI command)
 EOF
 }
-main() {
+main(){
   # Check for help
   [[ ${#} -eq 0 ]] && die "Usage: ${0##*/} <file|uri...>"
   for arg in "$@"; do

--- a/Home/.local/bin/pkgsync.sh
+++ b/Home/.local/bin/pkgsync.sh
@@ -12,12 +12,12 @@ IFS=$'\n\t'
 FILE_NATIVE="pkglist_native.txt"
 FILE_AUR="pkglist_aur.txt"
 
-check_deps() {
+check_deps(){
   need pacman
   need paru
 }
 
-do_export() {
+do_export(){
   log "Exporting native..."
   pacman -Qqne > "$FILE_NATIVE"
   log "Exporting AUR..."
@@ -25,7 +25,7 @@ do_export() {
   log "Done."
 }
 
-do_import() {
+do_import(){
   if [[ -s $FILE_NATIVE ]]; then
     log "Importing native..."
     run_priv pacman -S --needed - < "$FILE_NATIVE" || log "Native import issues."

--- a/Home/.local/bin/pkgui.sh
+++ b/Home/.local/bin/pkgui.sh
@@ -17,7 +17,7 @@ readonly PKGLIST="${PKGUI_PKGLIST:-$CFG/packagelist}"
 declare -A _pkgui_cmd_cache
 mkdir -p "$CFG" "$CACHE" "${HIST%/*}"
 # Utils
-_pkgui_has() {
+_pkgui_has(){
   if [[ -n ${_pkgui_cmd_cache[$1]} ]]; then
     return "${_pkgui_cmd_cache[$1]}"
   fi
@@ -28,14 +28,14 @@ _pkgui_has() {
   fi
   return "${_pkgui_cmd_cache[$1]}"
 }
-_pkgui_die() {
+_pkgui_die(){
   printf '%b[ERR]%b %s
 ' "$R" "$D" "$*" >&2
   exit 1
 }
-_pkgui_msg() { printf '%b%s%b
+_pkgui_msg(){ printf '%b%s%b
 ' "$G" "$*" "$D"; }
-_pkgui_warn() { printf '%b[WARN]%b %s
+_pkgui_warn(){ printf '%b[WARN]%b %s
 ' "$Y" "$D" "$*" >&2; }
 # Detect pkg mgr & fuzzy finder
 for p in ${PARUZ:-paru pacman}; do _pkgui_has "$p" && PAC="$p" && break; done
@@ -46,9 +46,9 @@ for f in ${FINDER:-sk fzf}; do _pkgui_has "$f" && FND="$f" && break; done
 FZF_THEME="${FZF_THEME:-hl:italic:#FFFF00,hl+:bold:underline:#FF0000,fg:#98A0C5,fg+:bold:#FFFFFF,bg:#13172A,bg+:#0F1222,border:#75A2F7,label:bold:#75A2F7,preview-fg:#C0CAF5,preview-bg:#0F1222,marker:#00FF00,pointer:#FF0000,query:#FF0000,info:italic:#98A0C5}"
 # Cache
 declare -A _CI _CQ _CL _CLO
-_pkgui_ver() { printf '%b%s%b v4.2.0 - Unified pacman/AUR TUI
+_pkgui_ver(){ printf '%b%s%b v4.2.0 - Unified pacman/AUR TUI
 ' "$BD" "${0##*/}" "$D"; }
-_pkgui_help() {
+_pkgui_help(){
   cat << 'EOF'
 USAGE  pkgui [CMD|FLAG] [ARGS]
 
@@ -91,7 +91,7 @@ FZF KEYS
   ?         Show keys           Esc/Ctrl-c Exit
 EOF
 }
-_pkgui_fzf() {
+_pkgui_fzf(){
   local -a o=(--ansi --cycle --reverse --inline-info --no-scrollbar)
   o+=(--color="$FZF_THEME" --history="$HIST")
   if [[ $FND == sk ]]; then o+=(--no-hscroll); fi
@@ -122,7 +122,7 @@ _pkgui_fzf() {
   done
   "$FND" "${o[@]}"
 }
-_pkgui_info() {
+_pkgui_info(){
   if [[ -n ${_CI[$1]:-} ]]; then {
     printf '%s
 ' "${_CI[$1]}"
@@ -134,7 +134,7 @@ _pkgui_info() {
   printf '%s
 ' "$r"
 }
-_pkgui_infoq() {
+_pkgui_infoq(){
   if [[ -n ${_CQ[$1]:-} ]]; then {
     printf '%s
 ' "${_CQ[$1]}"
@@ -146,7 +146,7 @@ _pkgui_infoq() {
   printf '%s
 ' "$r"
 }
-_pkgui_list() {
+_pkgui_list(){
   if [[ -n ${_CL[$*]:-} ]]; then {
     printf '%s
 ' "${_CL[$*]}"
@@ -158,7 +158,7 @@ _pkgui_list() {
   printf '%s
 ' "$r"
 }
-_pkgui_listq() {
+_pkgui_listq(){
   if [[ -n ${_CLO[$*]:-} ]]; then {
     printf '%s
 ' "${_CLO[$*]}"
@@ -170,7 +170,7 @@ _pkgui_listq() {
   printf '%s
 ' "$r"
 }
-_pkgui_prev_pkg() {
+_pkgui_prev_pkg(){
   local pkg=$1 mode=${2:-repo}
   if [[ $mode == aur ]]; then
     printf "=== Package Info ===
@@ -193,7 +193,7 @@ _pkgui_prev_pkg() {
     _pkgui_info "$pkg"
   fi
 }
-_pkgui_search() {
+_pkgui_search(){
   export -f _pkgui_info _pkgui_fzf _pkgui_prev_pkg
   export PAC FND FZF_THEME HIST
   declare -gA _CI
@@ -209,7 +209,7 @@ Ctrl-u:update  Ctrl-/:layout  Ctrl-v:preview  ?:keys' \
     -b "alt-p:toggle-preview" \
     -b "ctrl-/:change-preview-window(down,60%|right,60%|hidden)"
 }
-_pkgui_local() {
+_pkgui_local(){
   export -f _pkgui_infoq _pkgui_fzf
   export PAC FND FZF_THEME HIST
   declare -gA _CQ
@@ -221,7 +221,7 @@ _pkgui_local() {
     -b "ctrl-s:execute(_pkgui_infoq {} | less -R)" \
     -b "ctrl-/:change-preview-window(down,60%|right,60%|hidden)"
 }
-_pkgui_browse_aur() {
+_pkgui_browse_aur(){
   export -f _pkgui_prev_pkg _pkgui_fzf
   export PAC FND FZF_THEME HIST
   _pkgui_msg "Loading AUR packages..."
@@ -233,7 +233,7 @@ _pkgui_browse_aur() {
     -b "ctrl-i:execute($PAC -S {} </dev/tty >/dev/tty 2>&1)" \
     -b "ctrl-s:execute($PAC -Si {} | less -R)"
 }
-_pkgui_orphans() {
+_pkgui_orphans(){
   export -f _pkgui_infoq _pkgui_fzf
   export PAC FND FZF_THEME HIST
   declare -gA _CQ
@@ -243,7 +243,7 @@ _pkgui_orphans() {
     -p "bash -c '_pkgui_infoq {}'" \
     -b "ctrl-r:execute($PAC -Rns {} </dev/tty >/dev/tty 2>&1)"
 }
-_pkgui_opt_deps() {
+_pkgui_opt_deps(){
   export -f _pkgui_infoq _pkgui_fzf
   export PAC FND FZF_THEME HIST
   declare -gA _CQ
@@ -252,25 +252,25 @@ _pkgui_opt_deps() {
     -l '[optional dep]' \
     -p "bash -c '_pkgui_infoq {}'"
 }
-_pkgui_inst() {
+_pkgui_inst(){
   local -a p
   mapfile -t p
   if ((${#p[@]} == 0)); then return 0; fi
   if [[ $PAC == pacman ]]; then sudo pacman -S "${p[@]}"; else "$PAC" -S "${p[@]}"; fi
 }
-_pkgui_dl() {
+_pkgui_dl(){
   local -a p
   mapfile -t p
   if ((${#p[@]} == 0)); then return 0; fi
   if [[ $PAC == pacman ]]; then sudo pacman -Syw "${p[@]}"; else "$PAC" -Syw "${p[@]}"; fi
 }
-_pkgui_rm() {
+_pkgui_rm(){
   local -a p
   mapfile -t p
   if ((${#p[@]} == 0)); then return 0; fi
   if [[ $PAC == pacman ]]; then sudo pacman -Rns --nosave "${p[@]}"; else "$PAC" -Rns --nosave "${p[@]}"; fi
 }
-_pkgui_upd_check() {
+_pkgui_upd_check(){
   _pkgui_msg "Checking updates..."
   local pac aur=0 flat=0
   pac=$(checkupdates 2> /dev/null | wc -l)
@@ -288,7 +288,7 @@ _pkgui_upd_check() {
   printf '
 '
 }
-_pkgui_upd_full() {
+_pkgui_upd_full(){
   _pkgui_msg "Full system update..."
   if [[ $PAC == pacman ]]; then sudo pacman -Syu; else "$PAC" -Syu; fi
   if _pkgui_has flatpak; then
@@ -298,7 +298,7 @@ _pkgui_upd_full() {
   fi
   _pkgui_msg "Update complete!"
 }
-_pkgui_upd_flat() {
+_pkgui_upd_flat(){
   if ! _pkgui_has flatpak; then
     _pkgui_warn "Flatpak not installed"
     return 1
@@ -307,7 +307,7 @@ _pkgui_upd_flat() {
   flatpak update -y --noninteractive
   sudo flatpak update -y --noninteractive
 }
-_pkgui_vulns() {
+_pkgui_vulns(){
   if ! _pkgui_has arch-audit; then
     _pkgui_warn "Install: sudo pacman -S arch-audit"
     return 1
@@ -315,7 +315,7 @@ _pkgui_vulns() {
   _pkgui_msg "Checking vulnerabilities (CVE)..."
   arch-audit -u || echo "No vulnerable packages"
 }
-_pkgui_news() {
+_pkgui_news(){
   if ! _pkgui_has curl; then
     _pkgui_warn "curl required"
     return 1
@@ -399,7 +399,7 @@ AWK
     | grep -E '<title>|<pubDate>|<link>' | sed -e 's/<[^>]*>//g' -e 's/^[[:space:]]*//' \
     | paste - - - | head -n 5 | awk -F'	' "$awk_script_news"
 }
-_pkgui_status() {
+_pkgui_status(){
   _pkgui_msg "Server status check..."
   printf '
 %bArchlinux.org:%b ' "$BD" "$D"
@@ -421,7 +421,7 @@ _pkgui_status() {
 ' "$R" "$D"
   fi
 }
-_pkgui_mirrors() {
+_pkgui_mirrors(){
   if _pkgui_has reflector; then
     _pkgui_msg "Updating mirrors (reflector)..."
     sudo reflector --verbose --protocol https --age 6 --sort rate --save /etc/pacman.d/mirrorlist
@@ -433,14 +433,14 @@ _pkgui_mirrors() {
     _pkgui_warn "Install reflector (Arch) or pacman-mirrors (Manjaro)"
   fi
 }
-_pkgui_clean() {
+_pkgui_clean(){
   _pkgui_msg "Cleaning cache..."
   if [[ $PAC == pacman ]]; then sudo pacman -Sc; else "$PAC" -Sc; fi
   if _pkgui_has paccache; then sudo paccache -rk2; fi
   if [[ -d $HOME/.cache/yay ]]; then paccache -rk1 --cachedir "$HOME/.cache/yay" &> /dev/null; fi
   if [[ -d $HOME/.cache/paru ]]; then paccache -rk1 --cachedir "$HOME/.cache/paru" &> /dev/null; fi
 }
-_pkgui_pacdiff() {
+_pkgui_pacdiff(){
   if ! _pkgui_has pacdiff; then
     _pkgui_warn "Install pacman-contrib"
     return 1
@@ -452,7 +452,7 @@ _pkgui_pacdiff() {
     sudo DIFFPROG="diff --side-by-side --suppress-common-lines --color=always" pacdiff
   fi
 }
-_pkgui_fw() {
+_pkgui_fw(){
   if ! _pkgui_has fwupdmgr; then
     _pkgui_warn "Install fwupd"
     return 1
@@ -467,7 +467,7 @@ _pkgui_fw() {
     if [[ ${ans,,} == y ]]; then fwupdmgr update; fi
   fi
 }
-_pkgui_svc() {
+_pkgui_svc(){
   _pkgui_msg "Checking failed systemd services..."
   local f
   f=$(systemctl --failed --no-pager --no-legend | wc -l)
@@ -477,7 +477,7 @@ _pkgui_svc() {
     echo "No failed services"
   fi
 }
-_pkgui_maint() {
+_pkgui_maint(){
   _pkgui_msg "System maintenance scan..."
   printf '
 %b=== Orphans ===%b
@@ -515,7 +515,7 @@ _pkgui_maint() {
   printf '
 '
 }
-_pkgui_gen_lists() {
+_pkgui_gen_lists(){
   local d="$CFG/lists"
   mkdir -p "$d"
   _pkgui_msg "Generating lists in $d..."
@@ -531,12 +531,12 @@ _pkgui_gen_lists() {
   _pkgui_msg "Generated: $d"
   find "$d" -name '*.txt' -exec ls -lh {} + | awk '{print $9,$5}'
 }
-_pkgui_backup() {
+_pkgui_backup(){
   local b="$PKGLIST.$(date +%Y%m%d-%H%M%S)"
   pacman -Qeq > "$b"
   _pkgui_msg "Backup: $b"
 }
-_pkgui_restore() {
+_pkgui_restore(){
   export -f _pkgui_fzf
   export FND FZF_THEME HIST
   local b
@@ -549,12 +549,12 @@ _pkgui_restore() {
   _pkgui_msg "Restoring: $b"
   if [[ $PAC == pacman ]]; then xargs -a "$b" sudo pacman -S --needed; else xargs -a "$b" "$PAC" -S --needed; fi
 }
-_pkgui_sync_list() {
+_pkgui_sync_list(){
   _pkgui_msg "Syncing packagelist..."
   pacman -Qeq | sort > "$PKGLIST"
   _pkgui_msg "Synced: $PKGLIST"
 }
-_pkgui_history() {
+_pkgui_history(){
   _pkgui_msg "Install history (last 200)..."
   grep -h '^\[.*\] \[ALPM\] \(installed\|removed\) ' /var/log/pacman.log* 2> /dev/null \
     | tail -1000 | sort \
@@ -564,7 +564,7 @@ _pkgui_history() {
     | grep -Fwf <(pacman -Qei | awk '/^Name/{name=$3}/^Install Reason/{if($4=="Explicitly")print name}') \
     | tail -200 | less -R
 }
-_pkgui_info_sys() {
+_pkgui_info_sys(){
   cat << EOF
 ${BD}=== System ===${D}
 ${BD}Host:${D}     $(hostname)
@@ -583,7 +583,7 @@ EOF
   printf '
 '
 }
-_pkgui_notify() {
+_pkgui_notify(){
   if ! _pkgui_has notify-send; then
     _pkgui_warn "Install libnotify"
     return 1
@@ -598,7 +598,7 @@ _pkgui_notify() {
     _pkgui_msg "Up to date"
   fi
 }
-_pkgui_edit_cfg() {
+_pkgui_edit_cfg(){
   local c="$CFG/config"
   if [[ ! -f $c ]]; then
     cat > "$c" << 'EOF'
@@ -610,7 +610,7 @@ EOF
   fi
   "${EDITOR:-nano}" "$c"
 }
-_pkgui_edit_sys() {
+_pkgui_edit_sys(){
   local -A files=(
     ["/etc/pacman.conf"]="Pacman config"
     ["/etc/pacman.d/mirrorlist"]="Mirrors"
@@ -644,7 +644,7 @@ _pkgui_edit_sys() {
   fi
 }
 # Main
-main() {
+main(){
   if [[ $# -eq 0 ]]; then
     _pkgui_help
     exit 0

--- a/Home/.local/bin/sanitize-filenames.sh
+++ b/Home/.local/bin/sanitize-filenames.sh
@@ -11,9 +11,9 @@ IFS=$'\n\t'
 
 need iconv
 if has sd; then
-  sanitize() { sd '[^A-Za-z0-9._-]+' '_' | sd '^_+|_+$' '' | sd '_+' '_'; }
+  sanitize(){ sd '[^A-Za-z0-9._-]+' '_' | sd '^_+|_+$' '' | sd '_+' '_'; }
 elif has sed; then
-  sanitize() { sed -E 's/[^A-Za-z0-9._-]+/_/g; s/^_+|_+$//g; s/_+/_/g'; }
+  sanitize(){ sed -E 's/[^A-Za-z0-9._-]+/_/g; s/^_+|_+$//g; s/_+/_/g'; }
 else
   die "sed/sd required"
 fi

--- a/Home/.local/bin/shopt.sh
+++ b/Home/.local/bin/shopt.sh
@@ -8,14 +8,11 @@ export LC_ALL=C LANG=C
 # Supports single files, directories, stdout output, and multi-variant compilation
 #──────────── Colors ────────────
 RED=$'\e[31m' GRN=$'\e[32m' YLW=$'\e[33m' DEF=$'\e[0m'
-has() { command -v "$1" &> /dev/null; }
-die() {
-  printf '%b%s%b\n' "$RED" "$*" "$DEF" >&2
-  exit 1
-}
-log() { printf '%b%s%b\n' "$GRN" "$*" "$DEF"; }
-warn() { printf '%b%s%b\n' "$YLW" "$*" "$DEF"; }
-usage() {
+has(){ command -v "$1" &> /dev/null; }
+die(){ printf '%b%s%b\n' "$RED" "$*" "$DEF" >&2; exit 1; }
+log(){ printf '%b%s%b\n' "$GRN" "$*" "$DEF"; }
+warn(){ printf '%b%s%b\n' "$YLW" "$*" "$DEF"; }
+usage(){
   cat << 'EOF'
 Usage: shopt [-rfmscCvh] [-o FILE] [-p PERM] [-e EXT] [-V VARIANT] <file_or_dir>
 
@@ -157,9 +154,9 @@ NR==1 && /^#!/ { print; next }
 { gsub(/[[:space:]]+#.*/, ""); gsub(/^[[:space:]]+|[[:space:]]+$/, ""); if(length) print }
 AWK
 #──────────── Function Normalizer ────────────
-normalize_functions() { sed -E 's/^[[:space:]]*function[[:space:]]+([a-zA-Z0-9_]+)[[:space:]]*\{/\1(){\n/g'; }
+normalize_functions(){ sed -E 's/^[[:space:]]*function[[:space:]]+([a-zA-Z0-9_]+)[[:space:]]*\{/\1(){\n/g'; }
 #──────────── Preprocessor Prep ────────────
-prep_preprocess() {
+prep_preprocess(){
   local in="$1" out="$2"
   : > "$out"
   while IFS= read -r line; do
@@ -167,7 +164,7 @@ prep_preprocess() {
   done < "$in"
 }
 #──────────── Enhanced Minifier ────────────
-minify_enhanced() {
+minify_enhanced(){
   local in="$1" out="$2"
   : > "$out"
   while IFS= read -r line; do
@@ -197,7 +194,7 @@ minify_enhanced() {
   sed -i -e '/^:[[:space:]]*'"'"'/,/^'"'"'/d' -e '/^#[[:space:]]*[-─]{5,}/d' "$out" 2> /dev/null || :
 }
 #──────────── Concatenate Files ────────────
-concat_files() {
+concat_files(){
   local base="$1" out="$2" rx="$5"
   local -n exts="$3" wlist="$4"
   : > "$out"
@@ -237,7 +234,7 @@ concat_files() {
   done
 }
 #──────────── Optimizer (Standard Mode) ────────────
-optimize() {
+optimize(){
   local f="$1" content
   local out_target="$f"
   # Handle output
@@ -283,7 +280,7 @@ optimize() {
   log "✓ $out_target"
 }
 #──────────── Compiler (Multi-Variant Mode) ────────────
-compile_variants() {
+compile_variants(){
   local base="$target"
   [[ -z $output ]] && die "Compile mode requires -o/--output"
   # Remove extension from output base

--- a/Home/.local/bin/wp.sh
+++ b/Home/.local/bin/wp.sh
@@ -23,7 +23,7 @@ elif [[ -r "$(dirname "$(realpath "$0")")/../lib/bash/stdlib.bash" ]]; then
 else
   # Minimal fallback if stdlib not available
   set -euo pipefail
-  has() { command -v "$1" &>/dev/null; }
+  has(){ command -v "$1" &>/dev/null; }
 fi
 
 # exit 0 - successful execution
@@ -34,7 +34,7 @@ WALLPAPERS_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/wallpapers"
 mkdir -p "$WALLPAPERS_DIR"
 QUIET=""
 
-send_feedback() {
+send_feedback(){
   local msg="$1"
   if [[ -z $QUIET ]]; then
     printf '%s\n' "$msg"
@@ -42,7 +42,7 @@ send_feedback() {
   fi
 }
 
-set_wallpaper() {
+set_wallpaper(){
   local wallpaper="$1"
   case "${XDG_SESSION_TYPE:-}" in
     wayland)
@@ -59,7 +59,7 @@ set_wallpaper() {
   esac
 }
 
-random_wallpaper() {
+random_wallpaper(){
   local wallpaper
   wallpaper=$(find "$WALLPAPERS_DIR" -type f -not -path '*/.git/*' | shuf -n 1) || {
     send_feedback "No file selected"
@@ -76,7 +76,7 @@ random_wallpaper() {
   fi
 }
 
-select_wallpaper() {
+select_wallpaper(){
   local wallpaper
   wallpaper=$(
     find "$WALLPAPERS_DIR" -type f -not -path '*/.git/*' -exec basename {} \; \

--- a/Home/.local/bin/yadm-sync.sh
+++ b/Home/.local/bin/yadm-sync.sh
@@ -11,11 +11,11 @@
 IFS=$'\n\t'
 
 # Alias for script compatibility
-success() { ok "$@"; }
-error() { err "$@"; }
+success(){ ok "$@"; }
+error(){ err "$@"; }
 
 # Determine repository directory
-get_repo_dir() {
+get_repo_dir(){
   if yadm rev-parse --show-toplevel &> /dev/null; then
     yadm rev-parse --show-toplevel
   elif [[ -d "${HOME}/.local/share/yadm/repo.git" ]]; then
@@ -26,7 +26,7 @@ get_repo_dir() {
 }
 
 # Show usage
-usage() {
+usage(){
   cat << EOF
 ${BLD}yadm-sync${DEF} - Sync dotfiles between ~/ and repository
 
@@ -63,7 +63,7 @@ EOF
 }
 
 # Sync from repo to home (deploy)
-sync_pull() {
+sync_pull(){
   local repo_dir home_dir dry_run="${1:-0}"
 
   repo_dir="$(get_repo_dir)"
@@ -90,7 +90,7 @@ sync_pull() {
 }
 
 # Sync from home to repo (update repo)
-sync_push() {
+sync_push(){
   local repo_dir home_dir dry_run="${1:-0}"
 
   repo_dir="$(get_repo_dir)"
@@ -182,7 +182,7 @@ EXCLUDES
 }
 
 # Show sync status
-sync_status() {
+sync_status(){
   local repo_dir home_dir
 
   repo_dir="$(get_repo_dir)"
@@ -201,7 +201,7 @@ sync_status() {
 }
 
 # Show detailed diff
-sync_diff() {
+sync_diff(){
   local repo_dir home_dir
 
   repo_dir="$(get_repo_dir)"
@@ -230,7 +230,7 @@ sync_diff() {
 }
 
 # Main
-main() {
+main(){
   local command="${1:-}"
   local dry_run=0
 

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ CYAN='\033[0;36m'
 NC='\033[0m' # No Color
 
 # Logo
-print_logo() {
+print_logo(){
   printf '%b\n' "$CYAN"
   cat << "EOF"
    ██████╗██╗   ██╗██████╗ ███████╗ ██████╗ ██████╗      ██████╗ ██████╗  ██████╗
@@ -27,7 +27,7 @@ EOF
 }
 
 # Get download folder path
-get_downloads_dir() {
+get_downloads_dir(){
   if [[ "$(uname)" == "Darwin" ]]; then
     echo "$HOME/Downloads"
   else
@@ -42,7 +42,7 @@ get_downloads_dir() {
 }
 
 # Get latest version
-get_latest_version() {
+get_latest_version(){
   printf '%b\n' "${CYAN}ℹ️ Checking latest version...${NC}"
   latest_release=$(curl -s https://api.github.com/repos/yeongpin/cursor-free-vip/releases/latest) || {
     printf '%b\n' "${RED}❌ Cannot get latest version information${NC}"
@@ -59,7 +59,7 @@ get_latest_version() {
 }
 
 # Detect system type and architecture
-detect_os() {
+detect_os(){
   if [[ "$(uname)" == "Darwin" ]]; then
     # Detect macOS architecture
     ARCH=$(uname -m)
@@ -88,7 +88,7 @@ detect_os() {
 }
 
 # Install and download
-install_cursor_free_vip() {
+install_cursor_free_vip(){
   local downloads_dir=$(get_downloads_dir)
   local binary_name="CursorFreeVIP_${VERSION}_${OS}"
   local binary_path="${downloads_dir}/${binary_name}"
@@ -193,7 +193,7 @@ install_cursor_free_vip() {
 }
 
 # Main program
-main() {
+main(){
   print_logo
   get_latest_version
   detect_os

--- a/setup.sh
+++ b/setup.sh
@@ -14,16 +14,13 @@ BLK=$'\e[30m' RED=$'\e[31m' GRN=$'\e[32m' YLW=$'\e[33m'
 BLU=$'\e[34m' MGN=$'\e[35m' CYN=$'\e[36m' WHT=$'\e[37m'
 BWHT=$'\e[97m' DEF=$'\e[0m' BLD=$'\e[1m'
 
-has() { command -v "$1" &> /dev/null; }
-warn() { printf '%b\n' "${BLD}${YLW}==> WARNING:${BWHT} $1${DEF}"; }
-die() {
-  printf '%b\n' "${BLD}${RED}==> ERROR:${BWHT} $1${DEF}" >&2
-  exit 1
-}
-info() { printf '%b\n' "${BLD}${BLU}==>${BWHT} $1${DEF}"; }
-success() { printf '%b\n' "${BLD}${GRN}==>${BWHT} $1${DEF}"; }
+has(){ command -v "$1" &> /dev/null; }
+warn(){ printf '%b\n' "${BLD}${YLW}==> WARNING:${BWHT} $1${DEF}"; }
+die(){ printf '%b\n' "${BLD}${RED}==> ERROR:${BWHT} $1${DEF}" >&2; exit 1; }
+info(){ printf '%b\n' "${BLD}${BLU}==>${BWHT} $1${DEF}"; }
+success(){ printf '%b\n' "${BLD}${GRN}==>${BWHT} $1${DEF}"; }
 
-run_cmd() {
+run_cmd(){
   if [[ $DRY_RUN == true ]]; then
     printf '%b\n' "${BLD}${CYN}[DRY-RUN]${BWHT} $*${DEF}"
     return 0
@@ -32,7 +29,7 @@ run_cmd() {
 }
 
 #--- Argument Parsing ---#
-parse_args() {
+parse_args(){
   while [[ $# -gt 0 ]]; do
     case "$1" in
       --dry-run | -n)
@@ -57,7 +54,7 @@ parse_args() {
   done
 }
 
-show_help() {
+show_help(){
   cat << EOF
 ${BLD}Dotfiles Setup Script${DEF}
 Usage: $(basename "$0") [OPTIONS]
@@ -81,7 +78,7 @@ readonly TUCKR_DIR="$DOTFILES_DIR"
 readonly PARU_OPTS="--needed --noconfirm --skipreview --sudoloop --batchinstall --combinedupgrade"
 
 #--- Main Logic ---#
-main() {
+main(){
   install_packages
   setup_dotfiles
   deploy_dotfiles
@@ -90,7 +87,7 @@ main() {
 }
 
 #--- Functions ---#
-install_packages() {
+install_packages(){
   info "Installing packages..."
   local pkgs=(
     git gitoxide aria2 curl zsh fd sd ripgrep bat jq
@@ -106,7 +103,7 @@ install_packages() {
   fi
 }
 
-setup_dotfiles() {
+setup_dotfiles(){
   has yadm || die "yadm not found."
   if [[ ! -d $DOTFILES_DIR ]]; then
     info "Cloning dotfiles..."
@@ -118,7 +115,7 @@ setup_dotfiles() {
   fi
 }
 
-deploy_dotfiles() {
+deploy_dotfiles(){
   info "Deploying Home/ configs..."
   local repo_dir
   if has yadm && yadm rev-parse --git-dir &> /dev/null; then
@@ -141,7 +138,7 @@ deploy_dotfiles() {
   fi
 }
 
-tuckr_system_configs() {
+tuckr_system_configs(){
   info "Linking system configs..."
   has tuckr || die "tuckr not found."
   [[ -d $TUCKR_DIR ]] || die "Repo not found at $TUCKR_DIR."
@@ -158,7 +155,7 @@ tuckr_system_configs() {
   done
 }
 
-final_steps() {
+final_steps(){
   success "Setup complete."
   info "Run 'yadm status' to check state."
 }


### PR DESCRIPTION
- Fix spacing: change all `() {` to `(){}` for consistency
- Inline short functions (<128 chars) to single-line format
- Affected 27 shell scripts with -31 LOC net reduction

Changes:
∴ All function declarations now use compact `name(){}` format ∴ Multi-line utility functions (die, has, etc.) inlined where appropriate ∴ Improves readability and maintains consistency with bash idioms ∴ No functional changes, syntax verified with `bash -n`