### PR TITLE
Implement bluetooth service check in btctl.sh

### DIFF
--- a/Home/.local/bin/btctl.sh
+++ b/Home/.local/bin/btctl.sh
@@ -1,7 +1,20 @@
 #!/usr/bin/env bash
+set -euo pipefail
 # FZF Wrapper to connect to devices using bluetoothctl
-# TODO: check if bluetooh service is running if not, start it
+
+# Check if bluetooth service is running, start if not
+if ! systemctl is-active --quiet bluetooth.service; then
+  printf "Bluetooth service not running, starting...\n"
+  if command -v sudo &>/dev/null; then
+    sudo systemctl start bluetooth.service
+  else
+    systemctl start bluetooth.service
+  fi
+  sleep 1
+fi
+
 # TODO: retry mechanism if connection fails
 choice=$(bluetoothctl devices | fzf --prompt="Choose Device: " --height 40% --reverse -m)
-device=$(echo $choice | awk '{print $2}')
+device=$(printf '%s' "$choice" | awk '{print $2}')
+[[ -n $device ]] || exit 0
 bluetoothctl connect "$device"


### PR DESCRIPTION
- Add systemctl check to verify bluetooth.service is active
- Auto-start bluetooth service if not running (with sudo fallback)
- Add set -euo pipefail for better error handling
- Use printf instead of echo for better portability
- Add device validation before connection attempt

Resolves TODO: check if bluetooth service is running if not, start it