### PR TITLE
refactor(bash): standardize shell scripts with strict mode and compac…

### DIFF
--- a/Home/.local/bin/.lib.sh
+++ b/Home/.local/bin/.lib.sh
@@ -2,42 +2,35 @@
 # Common library functions for ~/.local/bin scripts
 # Source this file: source "${BASH_SOURCE%/*}/.lib.sh" 2>/dev/null || source ~/.local/bin/.lib.sh
 # Command availability check
-has() { command -v -- "$1" &>/dev/null; }
+has(){ command -v -- "$1" &>/dev/null; }
 # Error handling
-die() {
+die(){
   local exit_code="${2:-1}"
   printf '%b[ERROR]%b %s\n' '\e[1;31m' '\e[0m' "$1" >&2
   exit "$exit_code"
 }
 # Warning messages
-warn() { printf '%b[WARN]%b %s\n' '\e[1;33m' '\e[0m' "$*" >&2; }
+warn(){ printf '%b[WARN]%b %s\n' '\e[1;33m' '\e[0m' "$*" >&2; }
 # Info messages
-info() { printf '%b[INFO]%b %s\n' '\e[1;34m' '\e[0m' "$*"; }
+info(){ printf '%b[INFO]%b %s\n' '\e[1;34m' '\e[0m' "$*"; }
 # Success messages
-success() { printf '%b[OK]%b %s\n' '\e[1;32m' '\e[0m' "$*"; }
+success(){ printf '%b[OK]%b %s\n' '\e[1;32m' '\e[0m' "$*"; }
 # Color definitions
 if [[ -t 1 ]]; then
-  RED='\e[1;31m'
-  GREEN='\e[1;32m'
-  YELLOW='\e[1;33m'
-  BLUE='\e[1;34m'
-  MAGENTA='\e[1;35m'
-  CYAN='\e[1;36m'
-  WHITE='\e[1;37m'
-  BOLD='\e[1m'
-  DIM='\e[2m'
-  RESET='\e[0m'
+  RED='\e[1;31m' GREEN='\e[1;32m' YELLOW='\e[1;33m' BLUE='\e[1;34m'
+  MAGENTA='\e[1;35m' CYAN='\e[1;36m' WHITE='\e[1;37m'
+  BOLD='\e[1m' DIM='\e[2m' RESET='\e[0m'
 else
   RED='' GREEN='' YELLOW='' BLUE='' MAGENTA='' CYAN='' WHITE=''
   BOLD='' DIM='' RESET=''
 fi
 # Preferred modern tool alternatives (fallback to traditional)
-FD=$(has fd && echo fd || echo find)
-RG=$(has rg && echo rg || echo grep)
-BAT=$(has bat && echo bat || echo cat)
-SD=$(has sd && echo sd || echo sed)
-JQ=$(has jaq && echo jaq || has jq && echo jq || echo cat)
-ARIA2=$(has aria2c && echo aria2c || echo curl)
+FD=$(has fd && printf fd || printf find)
+RG=$(has rg && printf rg || printf grep)
+BAT=$(has bat && printf bat || printf cat)
+SD=$(has sd && printf sd || printf sed)
+JQ=$(has jaq && printf jaq || has jq && printf jq || printf cat)
+ARIA2=$(has aria2c && printf aria2c || printf curl)
 # Export for use in subshells
 export FD RG BAT SD JQ ARIA2
 export RED GREEN YELLOW BLUE MAGENTA CYAN WHITE BOLD DIM RESET

--- a/Home/.local/bin/autostart.sh
+++ b/Home/.local/bin/autostart.sh
@@ -10,4 +10,4 @@ if [[ $# -gt 0 ]];then files=("$@")
 else mapfile -t files < <(command -v fd &>/dev/null && fd -t f --base-path "$AUTOSTART_DIR" || find "$AUTOSTART_DIR" -type f -exec basename {} \;|fzf --prompt='autostart: ' --preview='cat {}' -m --header="$(printf '%s\n' 'enter:confirm' "${FZF_DEFAULT_HEADER:-}")")
 fi
 [[ ${#files[@]} -eq 0 ]] && { printf '%s\n' "No files selected." >&2;exit 1;}
-for file in "${files[@]}";do [[ -f "$AUTOSTART_DIR/$file" ]] && while IFS= read -r program;do [[ -n $program ]] && nohup "$program" &>/dev/null &;done <"$AUTOSTART_DIR/$file"||printf '%s\n' "Warning: File '$file' does not exist." >&2;done
+for file in "${files[@]}";do [[ -f "$AUTOSTART_DIR/$file" ]] && while IFS= read -r program;do [[ -n $program ]] && nohup "$program" &>/dev/null & done <"$AUTOSTART_DIR/$file"||printf '%s\n' "Warning: File '$file' does not exist." >&2;done

--- a/Home/.local/bin/btctl.sh
+++ b/Home/.local/bin/btctl.sh
@@ -1,13 +1,26 @@
 #!/usr/bin/env bash
-set -euo pipefail
-systemctl is-active --quiet bluetooth.service||{ printf "Bluetooth service not running, starting...\n";sudo systemctl start bluetooth.service;sleep 1;}
-choice=$(bluetoothctl devices|fzf --prompt="Choose Device: " --height 40% --reverse -m)
-device=$(printf '%s' "$choice"|awk '{print $2}')
-[[ -n $device ]]||exit 0
+set -euo pipefail;shopt -s nullglob globstar;IFS=$'\n\t'
+export LC_ALL=C LANG=C
+systemctl is-active --quiet bluetooth.service || {
+  printf "Bluetooth service not running, starting...\n"
+  sudo systemctl start bluetooth.service
+  sleep 1
+}
+choice=$(bluetoothctl devices | fzf --prompt="Choose Device: " --height 40% --reverse -m)
+device=$(printf '%s' "$choice" | awk '{print $2}')
+[[ -n $device ]] || exit 0
 max_retries=3 retry_count=0 delay=2
-while ((retry_count<=max_retries));do
-  ((retry_count>0)) && { printf "Retrying (%d/%d) in %ds...\n" "$retry_count" "$max_retries" "$delay";sleep "$delay";delay=$((delay*2));}
-  bluetoothctl connect "$device" && { printf "Successfully connected\n";exit 0;}
+while ((retry_count <= max_retries)); do
+  ((retry_count > 0)) && {
+    printf "Retrying (%d/%d) in %ds...\n" "$retry_count" "$max_retries" "$delay"
+    sleep "$delay"
+    delay=$((delay * 2))
+  }
+  bluetoothctl connect "$device" && {
+    printf "Successfully connected\n"
+    exit 0
+  }
   ((retry_count++))
 done
-printf "Failed after %d attempts\n" "$max_retries" >&2;exit 1
+printf "Failed after %d attempts\n" "$max_retries" >&2
+exit 1

--- a/Home/.local/bin/cht.sh
+++ b/Home/.local/bin/cht.sh
@@ -1,21 +1,22 @@
 #!/usr/bin/env bash
-set -euo pipefail;shopt -s nullglob globstar;IFS=$'\n\t';LC_ALL=C;LANG=C
-has(){ command -v "$1" &>/dev/null;}
-die(){ printf 'Error: %s\n' "$*" >&2;exit 1;}
-for c in curl wget2 wget;do has "$c" && HTTP="$c" && break;done
+set -euo pipefail;shopt -s nullglob globstar;IFS=$'\n\t'
+export LC_ALL=C LANG=C
+has(){ command -v "$1" &>/dev/null; }
+die(){ printf 'Error: %s\n' "$*" >&2; exit 1; }
+for c in curl wget2 wget; do has "$c" && HTTP="$c" && break; done
 [[ -z ${HTTP:-} ]] && die "curl/wget required"
-for f in sk fzf;do has "$f" && FZF="$f" && break;done
+for f in sk fzf; do has "$f" && FZF="$f" && break; done
 [[ -z ${FZF:-} ]] && die "sk/fzf required"
-get(){ case "$HTTP" in curl) curl -fsL "$@";;wget*) "$HTTP" -qO- "$@";;esac;}
+get(){ case "$HTTP" in curl) curl -fsL "$@" ;; wget*) "$HTTP" -qO- "$@" ;; esac; }
 readonly CHT_CACHE="${XDG_CACHE_HOME:-$HOME/.cache}/cht_list" CHT_URL="cheat.sh"
-cache(){ [[ -f $CHT_CACHE && -n "$(find "$CHT_CACHE" -mtime -7 2>/dev/null)" ]] && return;mkdir -p "${CHT_CACHE%/*}";get "${CHT_URL}/:list" >"$CHT_CACHE"||die "Failed to fetch list";}
+cache(){ [[ -f $CHT_CACHE && -n "$(find "$CHT_CACHE" -mtime -7 2>/dev/null)" ]] && return; mkdir -p "${CHT_CACHE%/*}"; get "${CHT_URL}/:list" >"$CHT_CACHE" || die "Failed to fetch list"; }
 browse(){
-  local sel q qlist url;cache
-  sel=$("$FZF" --ansi --reverse --cycle --prompt='cht> ' --preview="curl -fsL ${CHT_URL}/{} 2>/dev/null | head -50" --preview-window=right:70% <"$CHT_CACHE")||return 1
-  qlist=$(get "${CHT_URL}/${sel}/:list" 2>/dev/null||:)
-  [[ -n $qlist ]] && q=$(printf '%s' "$qlist"|"$FZF" --print-query --ansi --reverse --prompt="cht/${sel}> " --preview="curl -fsL ${CHT_URL}/${sel}/{1} 2>/dev/null || curl -fsL ${CHT_URL}/${sel}/{q} 2>/dev/null" --preview-window=right:70%|tail -1)||read -rp "Query [${sel}]: " q
-  q="${q// /+}";url="${CHT_URL}/${sel}${q:+/${q}}"
-  printf '\n→ %s\n\n' "$url";get "$url"
+  local sel q qlist url; cache
+  sel=$("$FZF" --ansi --reverse --cycle --prompt='cht> ' --preview="curl -fsL ${CHT_URL}/{} 2>/dev/null | head -50" --preview-window=right:70% <"$CHT_CACHE") || return 1
+  qlist=$(get "${CHT_URL}/${sel}/:list" 2>/dev/null || :)
+  [[ -n $qlist ]] && q=$(printf '%s' "$qlist" | "$FZF" --print-query --ansi --reverse --prompt="cht/${sel}> " --preview="curl -fsL ${CHT_URL}/${sel}/{1} 2>/dev/null || curl -fsL ${CHT_URL}/${sel}/{q} 2>/dev/null" --preview-window=right:70% | tail -1) || read -rp "Query [${sel}]: " q
+  q="${q// /+}"; url="${CHT_URL}/${sel}${q:+/${q}}"
+  printf '\n-> %s\n\n' "$url"; get "$url"
 }
 query(){
   local lang="${1:-}" topic="${2:-}" flags="" url
@@ -40,6 +41,6 @@ EXAMPLES:
 EOF
 }
 search=0 insens="" bound="" recur=""
-while getopts "sibruha" o;do case "$o" in s) search=1;;i) insens=1;search=1;;b) bound=1;search=1;;r) recur=1;search=1;;u) rm -f "$CHT_CACHE";cache;printf '✓ Cache updated\n';exit 0;;h|*) usage;exit 0;;esac;done
-shift $((OPTIND-1))
-[[ $# -eq 0 ]] && browse||query "$@"
+while getopts "sibruha" o; do case "$o" in s) search=1 ;; i) insens=1; search=1 ;; b) bound=1; search=1 ;; r) recur=1; search=1 ;; u) rm -f "$CHT_CACHE"; cache; printf 'Cache updated\n'; exit 0 ;; h|*) usage; exit 0 ;; esac; done
+shift $((OPTIND - 1))
+[[ $# -eq 0 ]] && browse || query "$@"

--- a/Home/.local/bin/dedupe.sh
+++ b/Home/.local/bin/dedupe.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 # Role: Interactive Deduplication Pipeline (Fclones -> Czkawka)
 # Usage: ./dedupe.sh <target_directory>
-
-set -euo pipefail
-IFS=$'\n\t'
+set -euo pipefail;shopt -s nullglob globstar;IFS=$'\n\t'
+export LC_ALL=C LANG=C
 
 # --- Configuration ---
 readonly TARGET="${1:-}"
@@ -13,7 +12,7 @@ readonly CZ_EXCLUDES=("-E" "*/.git" "*/tmp*")
 readonly CZ_COMMON=("-u" "-W" "-X" "-M" "${CZ_EXCLUDES[@]}")
 
 # --- Validation ---
-if [[ -z "$TARGET" || ! -d "$TARGET" ]]; then
+if [[ -z $TARGET || ! -d $TARGET ]]; then
   printf "Usage: %s <directory>\n" "$0" >&2
   exit 1
 fi
@@ -21,27 +20,26 @@ fi
 # --- Check Dependencies ---
 for tool in fclones czkawka-cli; do
   if ! command -v "$tool" &>/dev/null; then
-    printf "❌ Error: %s is not installed.\n" "$tool" >&2
+    printf "Error: %s is not installed.\n" "$tool" >&2
     exit 1
   fi
 done
 
 # --- Interaction ---
-
-printf "\n📂 Target: %s\n" "$TARGET"
+printf "\nTarget: %s\n" "$TARGET"
 
 # 1. Backup Verification
-printf "\n⚠️  SAFETY CHECK\n"
+printf "\nSAFETY CHECK\n"
 read -r -p "Have you created a backup of this directory? [y/N] " backup_ans
-if [[ ! "${backup_ans,,}" =~ ^y ]]; then
-  printf "❌ Aborting. Please backup your data first.\n"
+if [[ ! ${backup_ans,,} =~ ^y ]]; then
+  printf "Aborting. Please backup your data first.\n"
   exit 1
 fi
 
 # 2. Strategy Selection
-printf "\n⚙️  STRATEGY\n"
+printf "\nSTRATEGY\n"
 printf "1) Hardlink (Safe) - Replaces exact duplicates with hardlinks. Saves space, keeps filenames.\n"
-printf "2) Delete   (Risk) - Permanently deletes duplicates. \n"
+printf "2) Delete   (Risk) - Permanently deletes duplicates.\n"
 printf "3) Dry Run  (Info) - Scan and report only.\n"
 read -r -p "Select option [1-3]: " strat_ans
 
@@ -53,7 +51,7 @@ case "$strat_ans" in
   1)
     MODE="hardlink"
     FCLONES_CMD="link"
-    # Czkawka hardlink support via CLI is complex/varied; 
+    # Czkawka hardlink support via CLI is complex/varied;
     # we will skip Czkawka destructive actions in this mode to be safe.
     ;;
   2)
@@ -67,66 +65,64 @@ case "$strat_ans" in
 esac
 
 # --- Execution ---
+log(){ printf "\n[ %(%H:%M:%S)T ] %s\n" -1 "$*"; }
 
-log() { printf "\n🔹 [ %s ] %s\n" "$(date +%H:%M:%S)" "$*"; }
-
-run_fclones() {
+run_fclones(){
   log "Phase 1: Fclones (Exact Match)"
   local rpt="${RPT_PREFIX}_fclones.txt"
 
   # 1. Group
-  fclones group "$TARGET" > "$rpt"
-  
+  fclones group "$TARGET" >"$rpt"
+
   local cnt
   cnt=$(grep -c "^[0-9a-f]" "$rpt" || true)
 
-  if [[ "$cnt" -eq 0 ]]; then
+  if [[ $cnt -eq 0 ]]; then
     printf "   No exact duplicates found.\n"
     return
   fi
   printf "   Found %s groups.\n" "$cnt"
 
   # 2. Action
-  if [[ "$MODE" != "dry" ]]; then
-    printf "   ⚡ EXECUTING: fclones %s...\n" "$FCLONES_CMD"
-    fclones "$FCLONES_CMD" < "$rpt"
+  if [[ $MODE != "dry" ]]; then
+    printf "   EXECUTING: fclones %s...\n" "$FCLONES_CMD"
+    fclones "$FCLONES_CMD" <"$rpt"
   else
-    printf "   🚧 DRY RUN: See %s\n" "$rpt"
+    printf "   DRY RUN: See %s\n" "$rpt"
   fi
 }
 
-run_czkawka() {
+run_czkawka(){
   local type="$1"
   log "Phase 2: Czkawka ($type)"
 
   local cmd=("czkawka-cli" "$type" "$TARGET")
   cmd+=("${CZ_COMMON[@]}")
 
-  if [[ "$MODE" == "delete" ]]; then
+  if [[ $MODE == "delete" ]]; then
     # Danger: Apply user's delete flags
     cmd+=("-D" "AEN")
-    printf "   ⚡ EXECUTING: Deleting All Except Newest...\n"
+    printf "   EXECUTING: Deleting All Except Newest...\n"
     "${cmd[@]}"
-  elif [[ "$MODE" == "hardlink" && "$type" == "dup" ]]; then
+  elif [[ $MODE == "hardlink" && $type == "dup" ]]; then
     # Czkawka 'dup' can technically hardlink, but fclones usually handles this better.
     # We run dry here to avoid conflicts or complex flag mapping.
-    printf "   ℹ️  Skipping Czkawka action (Fclones handled hardlinks).\n"
+    printf "   Skipping Czkawka action (Fclones handled hardlinks).\n"
     "${cmd[@]}"
   else
-    printf "   🚧 DRY RUN: Scanning only...\n"
+    printf "   DRY RUN: Scanning only...\n"
     "${cmd[@]}"
   fi
 }
 
 # --- Main ---
-
 run_fclones
 
 # Only run destructive image/video scans if explicitly deleting.
 # You cannot hardlink "similar" images (they are different files).
 run_czkawka "dup"
 
-if [[ "$MODE" == "hardlink" ]]; then
+if [[ $MODE == "hardlink" ]]; then
   log "Skipping Fuzzy Image/Video scan (Cannot hardlink different files)."
 else
   run_czkawka "image"

--- a/Home/.local/bin/fmt-all.sh
+++ b/Home/.local/bin/fmt-all.sh
@@ -1,14 +1,15 @@
 #!/usr/bin/env bash
-set -euo pipefail;shopt -s nullglob globstar;IFS=$'\n\t';LC_ALL=C;LANG=C
-has(){ command -v -- "$1" &>/dev/null;}
+set -euo pipefail;shopt -s nullglob globstar;IFS=$'\n\t'
+export LC_ALL=C LANG=C
+has(){ command -v -- "$1" &>/dev/null; }
 has image-optimizer && image-optimizer -r --png-optimization-level max --zopfli-iterations 100 -i .
 has mdfmt && mdfmt . --width 120 -w
 has tombi && tombi format
 has yamlfmt && yamlfmt -continue_on_error "*.yaml"
-has shellharden && { shellharden --replace ./*.sh||:; shellharden --replace ./*.bash||:; shellharden --replace ./*.zsh||:;}
+has shellharden && { shellharden --replace ./*.sh || :; shellharden --replace ./*.bash || :; shellharden --replace ./*.zsh || :; }
 has biome && biome check --fix --unsafe --skip-parse-errors --no-errors-on-unmatched --html-formatter-line-width=120 --css-formatter-line-width=120 --json-formatter-line-width=120 --use-editorconfig=true --indent-style=space --format-with-errors=true --files-ignore-unknown=true --vcs-use-ignore-file=false .
 has ruff && ruff format --line-length 120 "${PWD:-.}"
 has black && black "${PWD:-.}"
-has gh && { gh tidy; gh poi;}
+has gh && { gh tidy; gh poi; }
 git gc --aggressive --prune=now; git repack -ab; git maintenance run
 git add -A; git commit -m "Format & Lint" && git push

--- a/Home/.local/bin/media-toolkit.sh
+++ b/Home/.local/bin/media-toolkit.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail; shopt -s nullglob globstar; IFS=$'\n\t'
+set -euo pipefail;shopt -s nullglob globstar;IFS=$'\n\t'
 export LC_ALL=C LANG=C HOME="/home/${SUDO_USER:-$USER}"
 # media-toolkit.sh - Optimized media manipulation tools
 # Colors
@@ -30,7 +30,7 @@ usb_write(){
   [[ $x == iso || $x == img ]] || die "need .iso/.img: $iso"
   [[ -b $dst ]] || die "not block device: $dst"
   if grep -q "$dst" /proc/mounts; then die "device mounted: $dst"; fi
-  log "⚠️  WARNING: DESTROY all data on $dst!"
+  log "WARNING: DESTROY all data on $dst!"
   read -rp "Continue? [y/N] " c
   [[ $c =~ ^[yY]$ ]] || { log "Cancelled"; exit 0; }
   sz=$(stat -c%s "$iso")
@@ -39,7 +39,6 @@ usb_write(){
   sudo dd if="$iso" bs=4M iflag=fullblock status=none \
     | pv --size "$sz" -pterb \
     | sudo dd of="$dst" bs=4M oflag=sync status=none
-    
   ok "Done"
 }
 iso2sd(){
@@ -52,7 +51,7 @@ iso2sd(){
 format_exfat(){
   local dev=$1 nm=$2
   [[ -b $dev ]] || die "not block: $dev"
-  log "⚠️  WARNING: Erasing $dev, label '$nm'"
+  log "WARNING: Erasing $dev, label '$nm'"
   read -rp "Continue? [y/N] " c
   [[ $c =~ ^[yY]$ ]] || { log "Cancelled"; exit 0; }
   sudo wipefs -a "$dev"
@@ -112,7 +111,7 @@ export_png_worker(){
   # 3. pngcrush (optional DPI)
   if ((dpi > 0)); then
     if pngcrush -brute -l9 -res "$dpi" -q "$f" "$tmp_cr" &>/dev/null; then
-      if [[ -s $tmp_cr ]] && (( $(stat -c%s "$tmp_cr") < $(stat -c%s "$f") )); then
+      if [[ -s $tmp_cr ]] && (($(stat -c%s "$tmp_cr") < $(stat -c%s "$f"))); then
         mv "$tmp_cr" "$f"
       fi
       rm -f "$tmp_cr"

--- a/Home/.local/bin/minify.sh
+++ b/Home/.local/bin/minify.sh
@@ -1,126 +1,151 @@
 #!/usr/bin/env bash
-set -euo pipefail;shopt -s nullglob;IFS=$'\n\t'
+set -euo pipefail;shopt -s nullglob globstar;IFS=$'\n\t'
 export LC_ALL=C LANG=C LANGUAGE=C
-readonly out="${1:-.}" jobs=$(nproc 2>/dev/null||echo 4)
+readonly out="${1:-.}" jobs=$(nproc 2>/dev/null || printf 4)
 readonly red=$'\e[31m' grn=$'\e[32m' ylw=$'\e[33m' rst=$'\e[0m'
-has(){ command -v -- "$1" &>/dev/null;}
-die(){ printf '%s✗%s %s\n' "$red" "$rst" "$*" >&2;exit 1;}
-ok(){ printf '%s✓%s %s (%d → %d%s)\n' "$grn" "$rst" "${1##*/}" "$2" "$3" "${4:+, $4}";}
-skip(){ printf '%s⊘%s %s (%s)\n' "$ylw" "$rst" "${1##*/}" "$2";}
-fail(){ printf '%s✗%s %s (%s)\n' "$red" "$rst" "${1##*/}" "$2" >&2;return 1;}
+has(){ command -v -- "$1" &>/dev/null; }
+die(){ printf '%sx%s %s\n' "$red" "$rst" "$*" >&2; exit 1; }
+ok(){ printf '%sv%s %s (%d -> %d%s)\n' "$grn" "$rst" "${1##*/}" "$2" "$3" "${4:+, $4}"; }
+skip(){ printf '%so%s %s (%s)\n' "$ylw" "$rst" "${1##*/}" "$2"; }
+fail(){ printf '%sx%s %s (%s)\n' "$red" "$rst" "${1##*/}" "$2" >&2; return 1; }
 check_deps(){
   local -a m=()
-  has minify||has bunx||has npx||m+=(minify/bun/node)
-  has jaq||has jq||has minify||m+=(jaq/jq/minify)
-  has awk||m+=(awk)
-  ((${#m[@]}>0))&& die "Missing: ${m[*]}"
+  has minify || has bunx || has npx || m+=(minify/bun/node)
+  has jaq || has jq || has minify || m+=(jaq/jq/minify)
+  has awk || m+=(awk)
+  ((${#m[@]} > 0)) && die "Missing: ${m[*]}"
 }
 minify_css(){
-  local f=$1 tmp=$(mktemp) in=$(wc -c<"$f") out
-  [[ $f =~ \.min\.css$ ]]&& return 0
-  if has minify;then
-    minify --type css -o "$tmp" "$f" &>/dev/null||{ rm -f "$tmp";fail "$f" "minify failed";}
-  elif has bunx;then
-    bunx --bun lightningcss --minify "$f" -o "$tmp" &>/dev/null||{ rm -f "$tmp";fail "$f" "lightningcss failed";}
-  elif has npx;then
-    npx -y lightningcss --minify "$f" -o "$tmp" &>/dev/null||{ rm -f "$tmp";fail "$f" "lightningcss failed";}
+  local f=$1 tmp out
+  tmp=$(mktemp)
+  local in
+  in=$(wc -c <"$f")
+  [[ $f =~ \.min\.css$ ]] && return 0
+  if has minify; then
+    minify --type css -o "$tmp" "$f" &>/dev/null || { rm -f "$tmp"; fail "$f" "minify failed"; }
+  elif has bunx; then
+    bunx --bun lightningcss --minify "$f" -o "$tmp" &>/dev/null || { rm -f "$tmp"; fail "$f" "lightningcss failed"; }
+  elif has npx; then
+    npx -y lightningcss --minify "$f" -o "$tmp" &>/dev/null || { rm -f "$tmp"; fail "$f" "lightningcss failed"; }
   else
-    rm -f "$tmp";skip "$f" "no css minifier";return 0
+    rm -f "$tmp"; skip "$f" "no css minifier"; return 0
   fi
-  out=$(wc -c<"$tmp");mv -f "$tmp" "$f";ok "$f" "$in" "$out"
+  out=$(wc -c <"$tmp"); mv -f "$tmp" "$f"; ok "$f" "$in" "$out"
 }
 minify_html(){
-  local f=$1 tmp=$(mktemp) in=$(wc -c<"$f") out
-  if has minify;then
-    minify --type html -o "$tmp" "$f" &>/dev/null||{ rm -f "$tmp";fail "$f" "minify failed";}
+  local f=$1 tmp out
+  tmp=$(mktemp)
+  local in
+  in=$(wc -c <"$f")
+  if has minify; then
+    minify --type html -o "$tmp" "$f" &>/dev/null || { rm -f "$tmp"; fail "$f" "minify failed"; }
   else
-    rm -f "$tmp";skip "$f" "minify not installed";return 0
+    rm -f "$tmp"; skip "$f" "minify not installed"; return 0
   fi
-  out=$(wc -c<"$tmp");mv -f "$tmp" "$f";ok "$f" "$in" "$out"
+  out=$(wc -c <"$tmp"); mv -f "$tmp" "$f"; ok "$f" "$in" "$out"
 }
 minify_json(){
-  local f=$1 tmp=$(mktemp) in=$(wc -c<"$f") out
-  [[ $f =~ \.min\.json$|package(-lock)?\.json$ ]]&& return 0
-  if has jaq;then
-    jaq -c . "$f">"$tmp" 2>/dev/null||{ rm -f "$tmp";fail "$f" "jaq failed";}
-  elif has jq;then
-    jq -c . "$f">"$tmp" 2>/dev/null||{ rm -f "$tmp";fail "$f" "jq failed";}
-  elif has minify;then
-    minify --type json -o "$tmp" "$f" &>/dev/null||{ rm -f "$tmp";fail "$f" "minify failed";}
+  local f=$1 tmp out
+  tmp=$(mktemp)
+  local in
+  in=$(wc -c <"$f")
+  [[ $f =~ \.min\.json$|package(-lock)?\.json$ ]] && return 0
+  if has jaq; then
+    jaq -c . "$f" >"$tmp" 2>/dev/null || { rm -f "$tmp"; fail "$f" "jaq failed"; }
+  elif has jq; then
+    jq -c . "$f" >"$tmp" 2>/dev/null || { rm -f "$tmp"; fail "$f" "jq failed"; }
+  elif has minify; then
+    minify --type json -o "$tmp" "$f" &>/dev/null || { rm -f "$tmp"; fail "$f" "minify failed"; }
   else
-    rm -f "$tmp";skip "$f" "no json minifier";return 0
+    rm -f "$tmp"; skip "$f" "no json minifier"; return 0
   fi
-  out=$(wc -c<"$tmp");mv -f "$tmp" "$f";ok "$f" "$in" "$out"
+  out=$(wc -c <"$tmp"); mv -f "$tmp" "$f"; ok "$f" "$in" "$out"
 }
 minify_xml(){
-  local f=$1 tmp=$(mktemp) in=$(wc -c<"$f") out
-  [[ $f =~ \.min\.xml$ ]]&& return 0
-  if has minify;then
-    minify --type xml -o "$tmp" "$f" &>/dev/null||{ rm -f "$tmp";fail "$f" "minify failed";}
-  elif has xmllint;then
-    xmllint --noblanks "$f">"$tmp" 2>/dev/null||{ rm -f "$tmp";fail "$f" "xmllint failed";}
+  local f=$1 tmp out
+  tmp=$(mktemp)
+  local in
+  in=$(wc -c <"$f")
+  [[ $f =~ \.min\.xml$ ]] && return 0
+  if has minify; then
+    minify --type xml -o "$tmp" "$f" &>/dev/null || { rm -f "$tmp"; fail "$f" "minify failed"; }
+  elif has xmllint; then
+    xmllint --noblanks "$f" >"$tmp" 2>/dev/null || { rm -f "$tmp"; fail "$f" "xmllint failed"; }
   else
-    rm -f "$tmp";skip "$f" "no xml minifier";return 0
+    rm -f "$tmp"; skip "$f" "no xml minifier"; return 0
   fi
-  out=$(wc -c<"$tmp");mv -f "$tmp" "$f";ok "$f" "$in" "$out"
+  out=$(wc -c <"$tmp"); mv -f "$tmp" "$f"; ok "$f" "$in" "$out"
 }
 minify_pdf(){
-  local f=$1 tmp=$(mktemp --suffix=.pdf) in=$(wc -c<"$f") out tool
-  [[ $f =~ \.min\.pdf$ ]]&& return 0
-  if has pdfinfo;then
-    local prod=$(pdfinfo "$f" 2>/dev/null|grep -F Producer||:)
-    [[ $prod =~ Ghostscript|cairo ]]&& { skip "$f" "already processed";rm -f "$tmp";return 0;}
+  local f=$1 tmp out tool
+  tmp=$(mktemp --suffix=.pdf)
+  local in
+  in=$(wc -c <"$f")
+  [[ $f =~ \.min\.pdf$ ]] && return 0
+  if has pdfinfo; then
+    local prod
+    prod=$(pdfinfo "$f" 2>/dev/null | grep -F Producer || :)
+    [[ $prod =~ Ghostscript|cairo ]] && { skip "$f" "already processed"; rm -f "$tmp"; return 0; }
   fi
-  if has qpdf && qpdf --linearize --object-streams=generate --compress-streams=y --recompress-flate "$f" "$tmp" &>/dev/null;then
+  if has qpdf && qpdf --linearize --object-streams=generate --compress-streams=y --recompress-flate "$f" "$tmp" &>/dev/null; then
     tool=qpdf
-  elif has gs && gs -q -dSAFER -dBATCH -dNOPAUSE -sDEVICE=pdfwrite -dCompatibilityLevel=1.7 -dDetectDuplicateImages=true -dSubsetFonts=true -dCompressFonts=true -sOutputFile="$tmp" -c 33550336 setvmthreshold -f "$f" &>/dev/null;then
+  elif has gs && gs -q -dSAFER -dBATCH -dNOPAUSE -sDEVICE=pdfwrite -dCompatibilityLevel=1.7 -dDetectDuplicateImages=true -dSubsetFonts=true -dCompressFonts=true -sOutputFile="$tmp" -c 33550336 setvmthreshold -f "$f" &>/dev/null; then
     tool=gs
   else
-    rm -f "$tmp";fail "$f" "no optimizer"
+    rm -f "$tmp"; fail "$f" "no optimizer"
   fi
-  out=$(wc -c<"$tmp")
-  if ((out<in));then
-    mv -f "$tmp" "$f";ok "$f" "$in" "$out" "$tool"
+  out=$(wc -c <"$tmp")
+  if ((out < in)); then
+    mv -f "$tmp" "$f"; ok "$f" "$in" "$out" "$tool"
   else
-    rm -f "$tmp";skip "$f" "no reduction"
+    rm -f "$tmp"; skip "$f" "no reduction"
   fi
 }
 fmt_yaml(){
-  local f=$1 tmp=$(mktemp) in=$(wc -c<"$f") out
-  if has yamlfmt;then
-    yamlfmt -q "$f" -out "$tmp" &>/dev/null||{ rm -f "$tmp";fail "$f" "yamlfmt failed";}
-    out=$(wc -c<"$tmp");mv -f "$tmp" "$f";ok "$f" "$in" "$out"
+  local f=$1 tmp out
+  tmp=$(mktemp)
+  local in
+  in=$(wc -c <"$f")
+  if has yamlfmt; then
+    yamlfmt -q "$f" -out "$tmp" &>/dev/null || { rm -f "$tmp"; fail "$f" "yamlfmt failed"; }
+    out=$(wc -c <"$tmp"); mv -f "$tmp" "$f"; ok "$f" "$in" "$out"
   else
-    rm -f "$tmp";skip "$f" "yamlfmt not installed";return 0
+    rm -f "$tmp"; skip "$f" "yamlfmt not installed"; return 0
   fi
 }
 fmt_ini(){
-  local f=$1 tmp=$(mktemp) in=$(wc -c<"$f") out
-  awk 'function t(s){gsub(/^[ \t]+|[ \t]+$/,"",s);return s}/^[ \t]*([;#]|$)/{print;next}/^[ \t]*\[/{print t($0);next}match($0,/=/){print t(substr($0,1,RSTART-1))" = "t(substr($0,RSTART+1));next}' "$f">"$tmp" 2>/dev/null||{ rm -f "$tmp";fail "$f" "awk failed";}
-  out=$(wc -c<"$tmp");mv -f "$tmp" "$f";ok "$f" "$in" "$out"
+  local f=$1 tmp out
+  tmp=$(mktemp)
+  local in
+  in=$(wc -c <"$f")
+  awk 'function t(s){gsub(/^[ \t]+|[ \t]+$/,"",s);return s}/^[ \t]*([;#]|$)/{print;next}/^[ \t]*\[/{print t($0);next}match($0,/=/){print t(substr($0,1,RSTART-1))" = "t(substr($0,RSTART+1));next}' "$f" >"$tmp" 2>/dev/null || { rm -f "$tmp"; fail "$f" "awk failed"; }
+  out=$(wc -c <"$tmp"); mv -f "$tmp" "$f"; ok "$f" "$in" "$out"
 }
 fmt_conf(){
-  local f=$1 tmp=$(mktemp) in=$(wc -c<"$f") out
-  awk 'BEGIN{FS=" +";placeholder="\033";align_all_columns=z_get_var(align_all_columns,0);align_columns_if_first_matches=align_all_columns?0:z_get_var(align_columns_if_first_matches,0);align_columns=align_all_columns||align_columns_if_first_matches;align_comments=z_get_var(align_comments,1);comment_regex=align_comments?z_get_var(comment_regex,"[#;]"):""}/^[[:blank:]]*$/{if(!last_empty){c_print_section();if(output_lines){empty_pending=1}}last_empty=1;next}{sub(/^ +/,"",$0);if(empty_pending){print"";empty_pending=0}last_empty=0;if(align_columns_if_first_matches&&actual_lines&&(!comment_regex||$1!~"^"comment_regex"([^[:blank:]]|$)")&&$1!=setting){b_queue_entries()}entry_line++;section_line++;field_count[entry_line]=0;comment[section_line]="";for(i=1;i<=NF;i++){if(a_process_regex("[\"'\\\\]","(([^ \"'\''\\\\]|\\\\.)*(\"([^\"]|\\\\\")*\"|'\''([^'\'']|\\\\\\')*'\''))*([^ \\\\]|\\\\.|\\\\$)*")){a_store_field(field_value)}else if(comment_regex&&(a_process_regex(comment_regex,comment_regex".*",1))){sub(/ +$/,"",field_value);comment[section_line]=field_value}else if(length($i)){a_store_field($i"");a_replace_field(placeholder)}}if(field_count[entry_line]){if(!actual_lines){setting=entry[entry_line,1]}actual_lines++}}END{c_print_section()}function a_process_regex(r,v,s,_p,_d){if(match($i,r)){if(s&&RSTART>1){a_replace_field(substr($i,1,RSTART-1)" "substr($i,RSTART));return}_p=$0;sub("^( |"placeholder")*","",_p);if(match(_p,"^"v)){field_value=substr(_p,RSTART,RLENGTH);_d=length($0)-length(_p);$0=substr($0,1,RSTART-1+_d)placeholder substr($0,RSTART+RLENGTH+_d);return 1}}}function a_replace_field(v,_n){if(!match($0,"^ *[^ ]+( +[^ ]+){"(i-1)"}")){$i=v;return}_n=substr($0,RLENGTH+1);$0=substr($0,1,RLENGTH);$i="";$0=$0 v _n}function a_store_field(v,_l){field_count[entry_line]=i;entry[entry_line,i]=v;_l=length(v);field_width[i]=_l>field_width[i]?_l:field_width[i]}function b_queue_entries(_o,_i,_j,_l){_o=section_line-entry_line;for(_i=1;_i<=entry_line;_i++){_l="";for(_j=1;_j<=field_count[_i];_j++){if(align_columns&&actual_lines>1&&setting){_l=_l sprintf("%-"field_width[_j]"s ",entry[_i,_j])}else{_l=_l sprintf("%s ",entry[_i,_j])}}sub(" $","",_l);section[_o+_i]=_l}entry_line=0;actual_lines=0;for(_j in field_width){delete field_width[_j]}}function c_print_section(_i,_len,_max,_l){b_queue_entries();for(_i=1;_i<=section_line;_i++){_len=length(section[_i]);_max=_len>_max?_len:_max}for(_i=1;_i<=section_line;_i++){_l=section[_i];if(comment[_i]){_l=(_l~/[^\t]/?sprintf("%-"_max"s ",_l):_l)comment[_i]}print _l;output_lines++}section_line=0}function z_get_var(v,d){return z_is_set(v)?v:d}function z_is_set(v){return!(v==""&&v==0)}' "$f">"$tmp" 2>/dev/null||{ rm -f "$tmp";fail "$f" "awk failed";}
-  out=$(wc -c<"$tmp");mv -f "$tmp" "$f";ok "$f" "$in" "$out"
+  local f=$1 tmp out
+  tmp=$(mktemp)
+  local in
+  in=$(wc -c <"$f")
+  awk 'BEGIN{FS=" +";placeholder="\033";align_all_columns=z_get_var(align_all_columns,0);align_columns_if_first_matches=align_all_columns?0:z_get_var(align_columns_if_first_matches,0);align_columns=align_all_columns||align_columns_if_first_matches;align_comments=z_get_var(align_comments,1);comment_regex=align_comments?z_get_var(comment_regex,"[#;]"):""}/^[[:blank:]]*$/{if(!last_empty){c_print_section();if(output_lines){empty_pending=1}}last_empty=1;next}{sub(/^ +/,"",$0);if(empty_pending){print"";empty_pending=0}last_empty=0;if(align_columns_if_first_matches&&actual_lines&&(!comment_regex||$1!~"^"comment_regex"([^[:blank:]]|$)")&&$1!=setting){b_queue_entries()}entry_line++;section_line++;field_count[entry_line]=0;comment[section_line]="";for(i=1;i<=NF;i++){if(a_process_regex("[\"'\''\\\\]","(([^ \"'\''\\\\]|\\\\.)*(\"([^\"]|\\\\\")*\"|'\''([^'\'']|\\\\'\'')* '\''))*([^ \\\\]|\\\\.|\\\\$)*")){a_store_field(field_value)}else if(comment_regex&&(a_process_regex(comment_regex,comment_regex".*",1))){sub(/ +$/,"",field_value);comment[section_line]=field_value}else if(length($i)){a_store_field($i"");a_replace_field(placeholder)}}if(field_count[entry_line]){if(!actual_lines){setting=entry[entry_line,1]}actual_lines++}}END{c_print_section()}function a_process_regex(r,v,s,_p,_d){if(match($i,r)){if(s&&RSTART>1){a_replace_field(substr($i,1,RSTART-1)" "substr($i,RSTART));return}_p=$0;sub("^( |"placeholder")*","",_p);if(match(_p,"^"v)){field_value=substr(_p,RSTART,RLENGTH);_d=length($0)-length(_p);$0=substr($0,1,RSTART-1+_d)placeholder substr($0,RSTART+RLENGTH+_d);return 1}}}function a_replace_field(v,_n){if(!match($0,"^ *[^ ]+( +[^ ]+){"(i-1)"}")){$i=v;return}_n=substr($0,RLENGTH+1);$0=substr($0,1,RLENGTH);$i="";$0=$0 v _n}function a_store_field(v,_l){field_count[entry_line]=i;entry[entry_line,i]=v;_l=length(v);field_width[i]=_l>field_width[i]?_l:field_width[i]}function b_queue_entries(_o,_i,_j,_l){_o=section_line-entry_line;for(_i=1;_i<=entry_line;_i++){_l="";for(_j=1;_j<=field_count[_i];_j++){if(align_columns&&actual_lines>1&&setting){_l=_l sprintf("%-"field_width[_j]"s ",entry[_i,_j])}else{_l=_l sprintf("%s ",entry[_i,_j])}}sub(" $","",_l);section[_o+_i]=_l}entry_line=0;actual_lines=0;for(_j in field_width){delete field_width[_j]}}function c_print_section(_i,_len,_max,_l){b_queue_entries();for(_i=1;_i<=section_line;_i++){_len=length(section[_i]);_max=_len>_max?_len:_max}for(_i=1;_i<=section_line;_i++){_l=section[_i];if(comment[_i]){_l=(_l~/[^\t]/?sprintf("%-"_max"s ",_l):_l)comment[_i]}print _l;output_lines++}section_line=0}function z_get_var(v,d){return z_is_set(v)?v:d}function z_is_set(v){return!(v==""&&v==0)}' "$f" >"$tmp" 2>/dev/null || { rm -f "$tmp"; fail "$f" "awk failed"; }
+  out=$(wc -c <"$tmp"); mv -f "$tmp" "$f"; ok "$f" "$in" "$out"
 }
 export -f minify_css minify_html minify_json minify_xml minify_pdf fmt_yaml fmt_ini fmt_conf ok skip fail has
 export red grn ylw rst
 run_parallel(){
-  local fn=$1;shift
-  (($#==0))&& return 0
-  if has parallel;then
-    printf '%s\n' "$@"|parallel -j"$jobs" "$fn" {}||:
-  elif has xargs;then
-    printf '%s\n' "$@"|xargs -r -P"$jobs" -I{} bash -c "$fn \"\$@\"" _ {}||:
+  local fn=$1; shift
+  (($# == 0)) && return 0
+  if has parallel; then
+    printf '%s\n' "$@" | parallel -j"$jobs" "$fn" {} || :
+  elif has xargs; then
+    printf '%s\n' "$@" | xargs -r -P"$jobs" -I{} bash -c "$fn \"\$@\"" _ {} || :
   else
-    local f;for f in "$@";do "$fn" "$f"||:;done
+    local f; for f in "$@"; do "$fn" "$f" || :; done
   fi
 }
 process(){
   local -a css=() html=() json=() xml=() pdf=() yaml=() ini=() conf=()
   local ex='-Enode_modules -Edist -E.git -E.cache -Ebuild -Etarget -E__pycache__ -E.venv -E.npm -Evendor'
-  if has fd;then
+  if has fd; then
     mapfile -t css < <(fd -ecss -tf -E'*.min.css' $ex . "$out" 2>/dev/null)
     mapfile -t html < <(fd -ehtml -ehtm -tf $ex . "$out" 2>/dev/null)
     mapfile -t json < <(fd -ejson -tf -E'*.min.json' -E'package*.json' $ex . "$out" 2>/dev/null)
@@ -140,8 +165,8 @@ process(){
     mapfile -t ini < <(find "$out" -type f -name '*.ini' "${fp[@]}" 2>/dev/null)
     mapfile -t conf < <(find "$out" -type f \( -name '*.conf' -o -name '*.cfg' \) "${fp[@]}" 2>/dev/null)
   fi
-  local -i total=$((${#css[@]}+${#html[@]}+${#json[@]}+${#xml[@]}+${#pdf[@]}+${#yaml[@]}+${#ini[@]}+${#conf[@]}))
-  ((total==0))&& { skip "." "No files found";return 0;}
+  local -i total=$((${#css[@]} + ${#html[@]} + ${#json[@]} + ${#xml[@]} + ${#pdf[@]} + ${#yaml[@]} + ${#ini[@]} + ${#conf[@]}))
+  ((total == 0)) && { skip "." "No files found"; return 0; }
   run_parallel minify_css "${css[@]}"
   run_parallel minify_html "${html[@]}"
   run_parallel minify_json "${json[@]}"
@@ -150,6 +175,6 @@ process(){
   run_parallel fmt_yaml "${yaml[@]}"
   run_parallel fmt_ini "${ini[@]}"
   run_parallel fmt_conf "${conf[@]}"
-  printf '\n%s✓%s Processed %d files\n' "$grn" "$rst" "$total"
+  printf '\n%sv%s Processed %d files\n' "$grn" "$rst" "$total"
 }
-check_deps;process
+check_deps; process

--- a/Home/.local/bin/neko.sh
+++ b/Home/.local/bin/neko.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
-shopt -s nullglob globstar
-IFS=$'\n\t'
+set -euo pipefail;shopt -s nullglob globstar;IFS=$'\n\t'
 export LC_ALL=C LANG=C
 
 nekofetch(){

--- a/Home/.local/bin/oneclone.sh
+++ b/Home/.local/bin/oneclone.sh
@@ -1,8 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail;shopt -s nullglob globstar;IFS=$'\n\t'
+export LC_ALL=C LANG=C
 
-
-rmount(){ 
+rmount(){
   mkdir -p ~/OneDrive
   rclone mount onedrive: ~/OneDrive \
     --vfs-cache-mode full \
@@ -15,6 +15,7 @@ rmount(){
     --tpslimit 4 \
     --daemon
 }
+
 rtrans(){
   mkdir -p ~/OneDrive ~/Documents
   rclone copy ~/Documents onedrive:Documents \
@@ -24,4 +25,6 @@ rtrans(){
     --tpslimit 4 \
     --progress
 }
+
+# shellcheck disable=SC2139
 alias mount-drive="rclone mount onedrive: ~/OneDrive --vfs-cache-mode full --vfs-cache-max-size 10G --daemon"

--- a/Home/.local/bin/onedrive_log.sh
+++ b/Home/.local/bin/onedrive_log.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 # onedrive_log - Colorized OneDrive sync log viewer
-set -euo pipefail
-shopt -s nullglob globstar
-IFS=$'\n\t'
+set -euo pipefail;shopt -s nullglob globstar;IFS=$'\n\t'
 export LC_ALL=C LANG=C
 has(){ command -v "$1" &>/dev/null; }
 die(){ printf 'Error: %s\n' "$*" >&2; exit 1; }
@@ -14,10 +12,10 @@ has ag || has grep || die "ag or grep is required"
 has ccze && use_ccze=1 || use_ccze=0
 
 # Color definitions using tput for portability
-readonly blue=$(tput setaf 4 2>/dev/null || echo '')
-readonly magenta=$(tput setaf 5 2>/dev/null || echo '')
-readonly yellow=$(tput setaf 3 2>/dev/null || echo '')
-readonly normal=$(tput sgr0 2>/dev/null || echo '')
+readonly blue=$(tput setaf 4 2>/dev/null || printf '')
+readonly magenta=$(tput setaf 5 2>/dev/null || printf '')
+readonly yellow=$(tput setaf 3 2>/dev/null || printf '')
+readonly normal=$(tput sgr0 2>/dev/null || printf '')
 unit="${1:-onedrive}"
 # Stream journal output with colorization
 # Use -F for fixed-string matching (faster than regex)

--- a/Home/.local/bin/optimal-mtu.sh
+++ b/Home/.local/bin/optimal-mtu.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-set -euo pipefail; shopt -s nullglob
-IFS=$'\n\t' LC_ALL=C LANG=C
-export HOME="/home/${SUDO_USER:-$USER}"
+set -euo pipefail;shopt -s nullglob globstar;IFS=$'\n\t'
+export LC_ALL=C LANG=C HOME="/home/${SUDO_USER:-$USER}"
 has(){ command -v -- "$1" &>/dev/null; }
-die(){ echo "ERROR: $*" >&2; exit 1; }
+die(){ printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
 check_requirements(){
   local -a missing=() reqs=(ping ip)
   for req in "${reqs[@]}"; do
@@ -11,13 +11,15 @@ check_requirements(){
   done
   ((${#missing[@]})) && die "Missing tools: ${missing[*]}"
 }
-detect_ip_version(){ local addr="$1"; [[ $addr =~ : ]] && echo "6" || echo "4"; }
+
+detect_ip_version(){ local addr="$1"; [[ $addr =~ : ]] && printf '6' || printf '4'; }
+
 select_interface(){
   local -a ifaces
-  mapfile -t ifaces < <(ip -br link | awk '$1! ~/(lo|veth|docker|br-)/{print $1}')
+  mapfile -t ifaces < <(ip -br link | awk '$1!~/(lo|veth|docker|br-)/{print $1}')
   ((${#ifaces[@]})) || die "No valid interfaces found"
   if ((${#ifaces[@]} == 1)); then
-    echo "${ifaces[0]}"; return
+    printf '%s' "${ifaces[0]}"; return
   fi
   printf "Available interfaces:\n"
   for i in "${!ifaces[@]}"; do
@@ -26,8 +28,9 @@ select_interface(){
   local n
   read -rp "Select [1-${#ifaces[@]}]: " n
   [[ $n =~ ^[0-9]+$ && $n -ge 1 && $n -le ${#ifaces[@]} ]] || die "Invalid selection"
-  echo "${ifaces[$((n - 1))]}"
+  printf '%s' "${ifaces[$((n - 1))]}"
 }
+
 persist_mtu(){
   local iface=$1 mtu=$2
   if has nmcli && [[ -n $(nmcli -t dev | grep "^$iface:") ]]; then
@@ -35,26 +38,26 @@ persist_mtu(){
     conn=$(nmcli -t -f NAME,DEVICE con show --active | awk -F: -v i="$iface" '$2==i{print $1}')
     if [[ $conn ]]; then
       sudo nmcli con mod "$conn" 802-3-ethernet.mtu "$mtu"
-      echo "Persistent via NetworkManager: $conn"; return 0
+      printf 'Persistent via NetworkManager: %s\n' "$conn"; return 0
     fi
   fi
   if [[ -d /etc/netplan ]] && compgen -G "/etc/netplan/*.yaml" >/dev/null; then
     local netplan_file
     netplan_file=$(compgen -G "/etc/netplan/*.yaml" | head -1)
-    echo "Updating Netplan config: $netplan_file"
+    printf 'Updating Netplan config: %s\n' "$netplan_file"
     if grep -q "^ *$iface:" "$netplan_file" 2>/dev/null; then
       if grep -q "mtu:" "$netplan_file" 2>/dev/null; then
         sudo sed -i "s/mtu: [0-9]*/mtu: $mtu/" "$netplan_file"
       else
         sudo sed -i "/^ *$iface:/a\      mtu: $mtu" "$netplan_file"
       fi
-      sudo netplan apply &>/dev/null || echo "Run 'sudo netplan apply' to activate"
-      echo "Persistent via Netplan: $netplan_file"; return 0
+      sudo netplan apply &>/dev/null || printf "Run 'sudo netplan apply' to activate\n"
+      printf 'Persistent via Netplan: %s\n' "$netplan_file"; return 0
     fi
   fi
   if [[ -d /etc/systemd/network ]]; then
     local nwfile="/etc/systemd/network/99-$iface-mtu.network"
-    sudo tee "$nwfile" &>/dev/null << EOF
+    sudo tee "$nwfile" &>/dev/null <<EOF
 [Match]
 Name=$iface
 
@@ -62,7 +65,7 @@ Name=$iface
 MTUBytes=$mtu
 EOF
     sudo systemctl restart systemd-networkd &>/dev/null || :
-    echo "Persistent via systemd-networkd: $nwfile"; return 0
+    printf 'Persistent via systemd-networkd: %s\n' "$nwfile"; return 0
   fi
   if [[ -f /etc/network/interfaces ]]; then
     if grep -q "iface $iface inet" /etc/network/interfaces 2>/dev/null; then
@@ -71,12 +74,13 @@ EOF
       else
         sudo sed -i "/iface $iface inet/ a\    mtu $mtu" /etc/network/interfaces
       fi
-      echo "Persistent via /etc/network/interfaces"
+      printf 'Persistent via /etc/network/interfaces\n'
       sudo systemctl restart networking &>/dev/null || sudo ifdown "$iface" && sudo ifup "$iface" || :; return 0
     fi
   fi
-  echo "Manual persistence needed - no supported network manager found"
+  printf 'Manual persistence needed - no supported network manager found\n'
 }
+
 find_mtu_binary(){
   local srv="$1" iface="$2" lo=1200 hi=1500 mid opt ipver overhead ping_cmd
   ipver=$(detect_ip_version "$srv")
@@ -86,7 +90,7 @@ find_mtu_binary(){
   else
     overhead=28; ping_cmd="ping"
   fi
-  echo "Testing MTU to $srv (IPv$ipver) via binary search..."
+  printf 'Testing MTU to %s (IPv%s) via binary search...\n' "$srv" "$ipver"
   "$ping_cmd" -c1 -W1 "$srv" &>/dev/null || die "Server $srv unreachable"
   "$ping_cmd" -M 'do' -s$((lo - overhead)) -c1 "$srv" &>/dev/null || die "Min MTU $lo not viable"
   opt=$lo
@@ -99,8 +103,9 @@ find_mtu_binary(){
     fi
   done
   opt=$((opt - 4))
-  echo "Optimal MTU: $opt bytes (4-byte safety margin)"; echo "$opt"
+  printf 'Optimal MTU: %d bytes (4-byte safety margin)\n' "$opt"; printf '%d' "$opt"
 }
+
 find_mtu_incremental(){
   local srv="$1" iface="$2" step="$3" current last_ok min_mtu=1000 max_mtu=1500 ipver overhead ping_cmd
   ipver=$(detect_ip_version "$srv")
@@ -110,27 +115,27 @@ find_mtu_incremental(){
   else
     overhead=28; ping_cmd="ping"
   fi
-  echo "Testing MTU to $srv (IPv$ipver) via incremental (step=$step)..."
+  printf 'Testing MTU to %s (IPv%s) via incremental (step=%s)...\n' "$srv" "$ipver" "$step"
   "$ping_cmd" -c1 -W1 "$srv" &>/dev/null || die "Server $srv unreachable"
   sudo ip link set dev "$iface" mtu "$max_mtu" &>/dev/null || die "Cannot set initial MTU"
   current="$min_mtu"; last_ok="$min_mtu"
   while ((current <= max_mtu)); do
     printf "Testing MTU: %d...  " "$current"
     if "$ping_cmd" -M 'do' -s$((current - overhead)) -c1 -W1 "$srv" &>/dev/null; then
-      echo "OK"; last_ok="$current"
+      printf 'OK\n'; last_ok="$current"
     else
-      echo "FAIL - retrying..."
+      printf 'FAIL - retrying...\n'
       read -rt 0.5 -- <> <(:) &>/dev/null || :
       if "$ping_cmd" -M 'do' -s$((current - overhead)) -c1 -W1 "$srv" &>/dev/null; then
-        echo "  Retry OK"; last_ok="$current"
+        printf '  Retry OK\n'; last_ok="$current"
       else
-        echo "  Retry FAIL - stopping"; break
+        printf '  Retry FAIL - stopping\n'; break
       fi
     fi
     ((current += step))
   done
   last_ok=$((last_ok - 2))
-  echo "Optimal MTU: $last_ok bytes (2-byte safety margin)"; echo "$last_ok"
+  printf 'Optimal MTU: %d bytes (2-byte safety margin)\n' "$last_ok"; printf '%d' "$last_ok"
 }
 
 main(){
@@ -142,7 +147,7 @@ main(){
         step_mode=1 step_size="$OPTARG"
         [[ $step_size =~ ^[0-9]+$ && $step_size -ge 1 && $step_size -le 10 ]] || die "Step size must be 1-10" ;;
       h)
-        cat << EOF
+        cat <<EOF
 Usage: ${0##*/} [-s STEP] [SERVER]
 Find optimal MTU to SERVER (default: 8.8.8.8)
 Supports IPv4 and IPv6.
@@ -158,13 +163,13 @@ Examples:
   ${0##*/} 2606:4700:4700::1111  # IPv6 binary search
 EOF
         exit 0 ;;
-      *) die "Invalid option.  Use -h for help" ;;
+      *) die "Invalid option. Use -h for help" ;;
     esac
   done
   shift $((OPTIND - 1)); srv=${1:-8.8.8.8}
-  read -rp "Set MTU on interface?  (Y/n) " -n1 choice
+  read -rp "Set MTU on interface? (Y/n) " -n1 choice
   [[ $choice =~ ^[Nn]$ ]] && {
-    echo "Dry run only - no changes applied"
+    printf 'Dry run only - no changes applied\n'
     iface="(not selected)"
     if ((step_mode)); then
       find_mtu_incremental "$srv" "$iface" "$step_size" >/dev/null
@@ -173,7 +178,7 @@ EOF
     fi; return 0
   }
   iface=$(select_interface)
-  echo "Selected interface: $iface"
+  printf 'Selected interface: %s\n' "$iface"
   local mtu
   if ((step_mode)); then
     mtu=$(find_mtu_incremental "$srv" "$iface" "$step_size")
@@ -181,8 +186,9 @@ EOF
     mtu=$(find_mtu_binary "$srv" "$iface")
   fi
   sudo ip link set dev "$iface" mtu "$mtu" || die "Failed to set MTU on $iface"
-  echo "MTU set to $mtu on $iface"
+  printf 'MTU set to %s on %s\n' "$mtu" "$iface"
   read -rp "Make persistent? (y/N) " -n1 persist_choice
   [[ $persist_choice =~ ^[Yy]$ ]] && persist_mtu "$iface" "$mtu"
 }
+
 main "$@"

--- a/Home/.local/bin/pkgui.sh
+++ b/Home/.local/bin/pkgui.sh
@@ -217,7 +217,7 @@ _pkgui_edit_sys(){
 }
 main(){
   case "${1:-}" in
-    -s) shift;_pkgui_search "$@";;-S) shift;_pkgui_search "$@"|_pkgui_inst;;-l) _pkgui_local;;-R) _pkgui_local|_pkgui_rm;;-u) _pkgui_upd_full;;-i) _pkgui_info_sys;;-v) _pkgui_ver;exit 0;;-h) _pkgui_help;exit 0;;"")";;*) _pkgui_die "Invalid option: $1";;
+    -s) shift;_pkgui_search "$@";;-S) shift;_pkgui_search "$@"|_pkgui_inst;;-l) _pkgui_local;;-R) _pkgui_local|_pkgui_rm;;-u) _pkgui_upd_full;;-i) _pkgui_info_sys;;-v) _pkgui_ver;exit 0;;-h) _pkgui_help;exit 0;;"");;*) _pkgui_die "Invalid option: $1";;
   esac
   [[ $# -eq 0 ]] && _pkgui_menu
 }

--- a/Home/.local/bin/sysinfo.sh
+++ b/Home/.local/bin/sysinfo.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -euo pipefail;shopt -s nullglob globstar;IFS=$'\n\t';LC_ALL=C;LANG=C
+set -euo pipefail;shopt -s nullglob globstar;IFS=$'\n\t'
+export LC_ALL=C LANG=C
 readonly VERSION="3.0.0" BLD=$'\e[1m' GRN=$'\e[32m' BLU=$'\e[34m' YLW=$'\e[33m' CYN=$'\e[96m' RED=$'\e[31m' DEF=$'\e[0m'
 has(){ command -v "$1" &>/dev/null;}
 die(){ printf '%bERROR:%b %s\n' "${BLD}${RED}" "$DEF" "$*" >&2;exit "${2:-1}";}

--- a/Home/.local/bin/systool.sh
+++ b/Home/.local/bin/systool.sh
@@ -1,14 +1,11 @@
 #!/usr/bin/env bash
-set -euo pipefail
-shopt -s nullglob globstar extglob
-IFS=$'\n\t'
-LC_ALL=C LANG=C
-
-# --- Helpers ---
-has() { command -v "$1" &>/dev/null; }
-die() { printf '%b[ERROR]%b %s\n' '\e[1;31m' '\e[0m' "$*" >&2; exit "${2:-1}"; }
-warn() { printf '%b[WARN]%b %s\n' '\e[1;33m' '\e[0m' "$*" >&2; }
-log() { printf '%b[INFO]%b %s\n' '\e[1;34m' '\e[0m' "$*"; }
+set -euo pipefail;shopt -s nullglob globstar extglob;IFS=$'\n\t'
+export LC_ALL=C LANG=C
+# Helpers
+has(){ command -v "$1" &>/dev/null; }
+die(){ printf '%b[ERROR]%b %s\n' '\e[1;31m' '\e[0m' "$*" >&2; exit "${2:-1}"; }
+warn(){ printf '%b[WARN]%b %s\n' '\e[1;33m' '\e[0m' "$*" >&2; }
+log(){ printf '%b[INFO]%b %s\n' '\e[1;34m' '\e[0m' "$*"; }
 
 SUDO=""
 ((EUID != 0)) && has sudo && SUDO=sudo

--- a/Home/.local/bin/vnfetch.sh
+++ b/Home/.local/bin/vnfetch.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-set -euo pipefail; shopt -s nullglob globstar; IFS=$'\n\t' LC_ALL=C LANG=C
+set -euo pipefail;shopt -s nullglob globstar;IFS=$'\n\t'
+export LC_ALL=C LANG=C
 # vnfetch (ven0m0-fetch), for Arch/Debian based distros
 # Heavily overoptimized bash fetch
 # Credit:

--- a/Home/.local/bin/yadm-sync.sh
+++ b/Home/.local/bin/yadm-sync.sh
@@ -97,6 +97,6 @@ sync_diff(){
 main(){
   local command="${1:-}" dry_run=0;shift||:
   while [[ $# -gt 0 ]];do case "$1" in -h|--help) usage;exit 0;;-n|--dry-run) dry_run=1;shift;;-v|--verbose) set -x;shift;;*) die "Unknown option: $1";;esac;done
-  case "$command" in pull) sync_pull "$dry_run";;push) sync_push "$dry_run";;status) sync_status;;diff) sync_diff;;-h|--help|help) usage;exit 0;;""} die "No command specified";;*) die "Unknown command: $command";;esac
+  case "$command" in pull) sync_pull "$dry_run";;push) sync_push "$dry_run";;status) sync_status;;diff) sync_diff;;-h|--help|help) usage;exit 0;;"") die "No command specified";;*) die "Unknown command: $command";;esac
 }
 main "$@"


### PR DESCRIPTION
- Add unified safety header: set -euo pipefail;shopt -s nullglob globstar
- Export LC_ALL=C LANG=C for consistent locale
- Use compact function syntax: fn(){ ... }
- Normalize redirects to &>/dev/null
- Fix syntax errors in autostart.sh, pkgui.sh, yadm-sync.sh
- Apply consistent formatting across 21 scripts