### PR TITLE
Fix TODO items and shell script best practices

### DIFF
--- a/Home/.config/mpv/mpv.conf
+++ b/Home/.config/mpv/mpv.conf
@@ -25,11 +25,9 @@ ytdl-raw-options=cookies-from-browser=firefox
 ytdl-format=bestvideo[height<=?1080][fps<=?60][vcodec*=vp9|vcodec*=vp09|vcodec*=av01|vcodec*=avc1]+bestaudio/best
 
 # --- Quality ---
-# TODO: see which one is better
-#scale=ewa_lanczossharp
-#cscale=ewa_lanczossharp
-scale=spline36
-cscale=spline36
+# Using ewa_lanczossharp for best quality (modern GPU recommended)
+scale=ewa_lanczossharp
+cscale=ewa_lanczossharp
 dscale=mitchell
 correct-downscaling=yes
 linear-downscaling=yes

--- a/Home/.local/bin/appImage_to_desktop.sh
+++ b/Home/.local/bin/appImage_to_desktop.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -eo pipefail
+set -euo pipefail
 
 APPIMAGE_PATH="$1"
 if [[ -z "$APPIMAGE_PATH" ]]; then
@@ -21,7 +21,7 @@ if [[ "$2" == "--remove" ]]; then
     find "${ICON_FOLDER}" -maxdepth 1 -type f -name "$APP_NAME.*" -delete
     echo "Removed"; exit 0
 fi
-pushd $TEMP_SQUASHFS_PATH
+pushd "$TEMP_SQUASHFS_PATH"
 "$APPIMAGE_FULLPATH" --appimage-extract > /dev/null
 cd squashfs-root/
 echo "Choose icon: "
@@ -47,5 +47,5 @@ Terminal=false
 EOT
 
 popd
-rm -rf $TEMP_SQUASHFS_PATH
+rm -rf "$TEMP_SQUASHFS_PATH"
 echo "Created"

--- a/Home/.local/bin/killwine.sh
+++ b/Home/.local/bin/killwine.sh
@@ -1,4 +1,17 @@
-#!/bin/sh
-wineserver -k
-kill -9 $(ps -ef | grep -E -i '(wine|processid|\.exe)' | awk '{print $2}')
-killall -9 pressure-vessel-adverb
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Kill Wine processes safely
+has() { command -v "$1" &>/dev/null; }
+
+# Kill wine server
+has wineserver && wineserver -k || true
+
+# Kill wine-related processes
+mapfile -t pids < <(ps -ef | grep -E -i '(wine|processid|\.exe)' | grep -v grep | awk '{print $2}')
+if [[ ${#pids[@]} -gt 0 ]]; then
+  kill -9 "${pids[@]}" 2>/dev/null || true
+fi
+
+# Kill pressure vessel
+pkill -9 pressure-vessel-adverb 2>/dev/null || true

--- a/Home/.local/bin/proton-cachyos.sh
+++ b/Home/.local/bin/proton-cachyos.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 ## configuration
 # proton executable


### PR DESCRIPTION
Resolve straightforward tasks from in-code TODOs and shell standards:

- mpv.conf: Resolve scaling TODO, use ewa_lanczossharp for best quality
- appImage_to_desktop.sh: Add -u flag to set, quote variables per standards
- killwine.sh: Rewrite with proper error handling, use mapfile, avoid unsafe patterns
- proton-cachyos.sh: Fix shebang to #!/usr/bin/env bash, add set -euo pipefail

All changes align with repo standards: proper error handling, quoted variables, and bash idioms per CLAUDE.md guidelines.