### PR TITLE
⚡ Performance Improvement: Use iglob in vidconv.py

### DIFF
--- a/Home/.local/bin/vidconv.py
+++ b/Home/.local/bin/vidconv.py
@@ -451,7 +451,7 @@ def main() -> int:
     src_root = None
     files = []
     for pat in args.files:
-      for p in glob.glob(str(Path(pat).expanduser()), recursive=True):
+      for p in glob.iglob(str(Path(pat).expanduser()), recursive=True):
         path = Path(p)
         if path.is_file() and path.suffix.lower() in exts:
           if args.format == 'opus' and path.suffix.lower() in PASSTHROUGH_EXTS:


### PR DESCRIPTION
💡 **What:** Replaced `glob.glob()` with `glob.iglob()` in `Home/.local/bin/vidconv.py`.

🎯 **Why:** `glob.glob()` constructs a complete list of matching file paths in memory before iterating, which can cause significant memory usage when recursively scanning large directory structures (e.g., entire music libraries or video archives). `glob.iglob()` returns an iterator, yielding paths one by one, reducing the memory footprint during the file discovery phase.

📊 **Measured Improvement:** Verified functional equivalence using a reproduction script (`reproduce_glob.py`) which confirmed that `glob.iglob(recursive=True)` yields the exact same set of files as `glob.glob(recursive=True)`. This ensures the optimization is safe and correct without altering behavior. Benchmarks were skipped per user request as the memory benefit of iterators over lists for large collections is a standard Python optimization pattern.

---
*PR created automatically by Jules for task [1278564761436381932](https://jules.google.com/task/1278564761436381932) started by @Ven0m0*