### PR TITLE
🚀 Turbo: Optimize fzf-tools preview logic

### DIFF
--- a/benchmark_preview.sh
+++ b/benchmark_preview.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+export LC_ALL=C
+
+# create dummy files
+touch test.txt
+echo '{"a":1}' > test.json
+dd if=/dev/urandom of=test.bin bs=1024 count=1 2>/dev/null
+
+count=100
+
+echo "Benchmarking 'file --mime-type -b' ($count iterations)..."
+start=$(date +%s%N)
+for ((i=0; i<count; i++)); do
+  file --mime-type -b test.txt >/dev/null
+done
+end=$(date +%s%N)
+echo "file: $(( (end - start) / 1000000 )) ms total"
+
+echo "Benchmarking '[[ -d ]]' + extension check ($count iterations)..."
+start=$(date +%s%N)
+for ((i=0; i<count; i++)); do
+  if [[ -d test.txt ]]; then :;
+  elif [[ test.txt == *.json ]]; then :;
+  else :; fi
+done
+end=$(date +%s%N)
+echo "bash checks: $(( (end - start) / 1000000 )) ms total"
+
+echo "Benchmarking 'grep -qI .' (binary check) ($count iterations)..."
+start=$(date +%s%N)
+for ((i=0; i<count; i++)); do
+  grep -qI . test.bin 2>/dev/null
+done
+end=$(date +%s%N)
+echo "grep: $(( (end - start) / 1000000 )) ms total"
+
+rm test.txt test.json test.bin


### PR DESCRIPTION
Optimized `fzf-tools.sh` preview function to reduce latency and fix bugs.
- Replaced `$(batcmd)` subshell with cached `BAT_CMD`.
- Replaced `ext=$(ext_of ...)` subshell with global variable `_EXT` (pure bash).
- Added fast-path checks for directories (`[[ -d ]]`) and file extensions to skip slow `file --mime-type` calls.
- Fixed `set -u` crash by splitting `local` assignment.
- Removed harmful `cd` command that broke relative path resolution.
- Improved JSON preview to use `jq -C` directly, avoiding invalid JSON from `bat` decorations.

---
*PR created automatically by Jules for task [14492650967845755909](https://jules.google.com/task/14492650967845755909) started by @Ven0m0*