### PR TITLE
🧹 refactor: remove unused 'os' import from minify_font.py

### DIFF
--- a/Home/.local/bin/minify_font.py
+++ b/Home/.local/bin/minify_font.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-import os
 import sys
 from pathlib import Path
 


### PR DESCRIPTION
**What:** Removed the unused `import os` statement from `Home/.local/bin/minify_font.py`.

**Why:** Code cleanliness and maintainability. The `os` module was imported but never used in the script.

**Verification:**
- Ran `ruff check Home/.local/bin/minify_font.py` to confirm the unused import warning is resolved.
- Ran `python3 -m py_compile Home/.local/bin/minify_font.py` to ensure the script remains syntactically valid despite the missing `fontforge` dependency in the environment.

**Result:** The script is now cleaner and free of unused imports.

---
*PR created automatically by Jules for task [4346337153366169083](https://jules.google.com/task/4346337153366169083) started by @Ven0m0*