### PR TITLE
chore(vidconv): remove unused import 'as_completed'

### DIFF
--- a/Home/.local/bin/vidconv.py
+++ b/Home/.local/bin/vidconv.py
@@ -7,7 +7,7 @@ import shutil
 import subprocess
 import sys
 import time
-from concurrent.futures import ThreadPoolExecutor, as_completed, wait, FIRST_COMPLETED
+from concurrent.futures import ThreadPoolExecutor, wait, FIRST_COMPLETED
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Final, Iterable, Iterator


### PR DESCRIPTION
Removed unused import 'as_completed' from `Home/.local/bin/vidconv.py` to improve code cleanliness.

---
*PR created automatically by Jules for task [6244167061977282117](https://jules.google.com/task/6244167061977282117) started by @Ven0m0*