### PR TITLE
🔒 fix(setup): restrict REPO_RAW to HTTPS to prevent RFI/LFI

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -45,6 +45,9 @@ fetch_pkgfile() {
   if [[ -n $SCRIPT_DIR && -f "$SCRIPT_DIR/$path" ]]; then
     cat "$SCRIPT_DIR/$path"
   elif [[ -n $REPO_RAW ]]; then
+    if [[ ! $REPO_RAW =~ ^https:// ]]; then
+      die "Security: REPO_RAW must be an HTTPS URL."
+    fi
     curl -fsSL "${REPO_RAW%/}/$path"
   else
     warn "pkg/${name}.txt not found and REPO_RAW not set, skipping"


### PR DESCRIPTION
**What:**
Fixed a potential Remote/Local File Inclusion (RFI/LFI) vulnerability in `setup.sh` where `REPO_RAW` environment variable was used unsafely.

**Risk:**
If a user is tricked into setting `REPO_RAW` to a malicious URL (e.g., `file:///etc/passwd` or `http://evil.com`), the script would attempt to fetch and process package lists from that source. This could lead to information disclosure (LFI) or installation of malicious packages (RFI).

**Solution:**
Added a strict validation check ensuring `REPO_RAW` starts with `https://`. Any other protocol (including `http://` and `file://`) will trigger a fatal error and exit the script before `curl` is executed.
Verified the fix with a test harness that confirmed blocking of insecure protocols and allowance of valid HTTPS URLs.
Preserved original file formatting and escape sequences.

---
*PR created automatically by Jules for task [2313751582575012342](https://jules.google.com/task/2313751582575012342) started by @Ven0m0*