### PR TITLE
🧹 Remove unused logging functions and variables from shopt.sh

### DIFF
--- a/Home/.local/bin/shopt.sh
+++ b/Home/.local/bin/shopt.sh
@@ -6,16 +6,12 @@ IFS=$'\n\t'
 export LC_ALL=C
 
 has() { command -v -- "$1" &> /dev/null; }
-msg() { printf '%s\n' "$@"; }
-log() { printf '%s\n' "$@" >&2; }
 die() {
   printf '%s\n' "$1" >&2
   exit "${2:-1}"
 }
-readonly RED=$'\e[31m' GRN=$'\e[32m' YLW=$'\e[33m' DEF=$'\e[0m'
+readonly GRN=$'\e[32m' DEF=$'\e[0m'
 clog() { printf '%b%s%b\n' "$GRN" "$*" "$DEF" >&2; }
-cwarn() { printf '%b%s%b\n' "$YLW" "$*" "$DEF" >&2; }
-cerr() { printf '%b%s%b\n' "$RED" "$*" "$DEF" >&2; }
 
 usage() {
   cat << 'EOF'


### PR DESCRIPTION
🎯 **What:** The code health issue addressed was the presence of dead code in `Home/.local/bin/shopt.sh`. Specifically, the unused function `cerr` was removed, along with other unused logging helpers (`msg`, `log`, `cwarn`) and unused color variables (`RED`, `YLW`).
💡 **Why:** Removing dead code improves the maintainability and readability of the codebase by reducing clutter and potential confusion for future developers.
✅ **Verification:**
- Verified that the removed functions and variables were not referenced anywhere else in the script using `grep`.
- Confirmed the script remains syntactically correct by running `bash -n Home/.local/bin/shopt.sh`.
- Ran the full repository test suite using `pytest`, and all tests passed.
✨ **Result:** A cleaner and more maintainable `shopt.sh` script.

---
*PR created automatically by Jules for task [9151067947385127229](https://jules.google.com/task/9151067947385127229) started by @Ven0m0*