### PR TITLE
Fix Bluetooth issues with Xbox controllers

### DIFF
--- a/etc/modprobe.d/bluetooth.conf
+++ b/etc/modprobe.d/bluetooth.conf
@@ -1,5 +1,5 @@
 # Fix Bluetooth issues with Xbox controllers
-options bluetooth disable_ertm=1
+options bluetooth disable_ertm=Y
 options snd_hda_intel power_save=1
 options hid_xpadneo disable_shift_mode=1
 options btusb reset=1

--- a/etc/modules-load.d/modules-tweaks.conf
+++ b/etc/modules-load.d/modules-tweaks.conf
@@ -3,3 +3,4 @@ uinput
 # race that causes steam to fall back to evdev rather than hidraw.
 # hid_nintendo
 hid_playstation
+hid_xpadneo

--- a/pkg/pacman.txt
+++ b/pkg/pacman.txt
@@ -485,6 +485,7 @@ xorg-xinput
 xorg-xkill
 xorg-xrandr
 xorg-xwayland
+xpadneo-dkms
 xsettingsd
 yad
 yadm


### PR DESCRIPTION
This change addresses Bluetooth connectivity issues with Xbox controllers on Linux (CachyOS/Arch). It installs the recommended community driver `xpadneo-dkms`, ensures it is preloaded early to avoid conflicts with Steam's input handling, and tunes the Bluetooth module's ERTM setting for maximum compatibility.

---
*PR created automatically by Jules for task [11400374158196990029](https://jules.google.com/task/11400374158196990029) started by @Ven0m0*