### PR TITLE
🔒 [security fix] Explicitly set shell=False in subprocess calls

### DIFF
--- a/Home/.local/bin/vidconv.py
+++ b/Home/.local/bin/vidconv.py
@@ -228,7 +228,7 @@ def find_files_fd(root: Path, exts: frozenset[str]) -> Iterator[Path]:
     )
     try:
         with subprocess.Popen(
-            cmd, stdout=subprocess.PIPE, text=True, bufsize=1
+            cmd, stdout=subprocess.PIPE, text=True, bufsize=1, shell=False
         ) as proc:
             if proc.stdout:
                 for line in proc.stdout:
@@ -351,10 +351,14 @@ def run_ffmpeg(
     try:
         if quiet:
             subprocess.run(
-                cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL
+                cmd,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                shell=False,
             )
         else:
-            subprocess.run(cmd, check=True)
+            subprocess.run(cmd, check=True, shell=False)
         return True
     except subprocess.CalledProcessError:
         return False


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
Explicitly set `shell=False` in all `subprocess` calls within `Home/.local/bin/vidconv.py`.

### ⚠️ Risk: The potential impact if left unfixed
While `subprocess` defaults to `shell=False` when a list is passed as the first argument, not explicitly defining it could lead to potential shell injection vulnerabilities if the command structure is accidentally changed to a string in the future.

### 🛡️ Solution: How the fix addresses the vulnerability
The fix adds `shell=False` to the `subprocess.Popen` call in `find_files_fd` and both `subprocess.run` calls in `run_ffmpeg`. This ensures consistent security practices and hardens the script against command injection. Existing tests were run to ensure no functionality is broken.

---
*PR created automatically by Jules for task [6169826084680358034](https://jules.google.com/task/6169826084680358034) started by @Ven0m0*