### PR TITLE
🧪 Add tests for gen_out_path in vidconv.py

### DIFF
--- a/tests/test_vidconv_out_path.py
+++ b/tests/test_vidconv_out_path.py
@@ -1,0 +1,69 @@
+import importlib.util
+import pathlib
+from pathlib import Path
+import sys
+
+# Load the script as a module
+script_path = pathlib.Path("Home/.local/bin/vidconv.py").resolve()
+spec = importlib.util.spec_from_file_location("vidconv", script_path)
+vidconv = importlib.util.module_from_spec(spec)
+sys.modules["vidconv"] = vidconv
+spec.loader.exec_module(vidconv)
+
+
+def test_gen_out_path_basic():
+    inp = Path("/tmp/input/video.mp4")
+    preset = vidconv.Preset(name="test", suffix=".test", params=(), ext="mkv")
+    cfg = vidconv.Config()
+
+    out = vidconv.gen_out_path(inp, preset, cfg, out_dir=None, src_root=None)
+
+    assert out == Path("/tmp/input/video.test.mkv")
+
+
+def test_gen_out_path_formatting():
+    inp = Path("video.mp4")
+    preset = vidconv.Preset(
+        name="test", suffix=".crf{crf}-gr{grain}", params=(), ext="mkv"
+    )
+    cfg = vidconv.Config(crf=23, grain=4)
+
+    out = vidconv.gen_out_path(inp, preset, cfg, out_dir=None, src_root=None)
+
+    assert out == Path("video.crf23-gr4.mkv")
+
+
+def test_gen_out_path_sanitization():
+    inp = Path("video.mp4")
+    # suffix with characters that should be stripped if not in ._-+ or alnum
+    preset = vidconv.Preset(name="test", suffix=".test!@#$%", params=(), ext="mkv")
+    cfg = vidconv.Config()
+
+    out = vidconv.gen_out_path(inp, preset, cfg, out_dir=None, src_root=None)
+
+    assert out == Path("video.test.mkv")
+
+
+def test_gen_out_path_with_out_dir(tmp_path):
+    inp = Path("/some/path/video.mp4")
+    out_dir = tmp_path / "output"
+    preset = vidconv.Preset(name="test", suffix=".test", params=(), ext="mkv")
+    cfg = vidconv.Config()
+
+    out = vidconv.gen_out_path(inp, preset, cfg, out_dir=out_dir, src_root=None)
+
+    assert out == out_dir / "video.test.mkv"
+    assert out_dir.exists()
+
+
+def test_gen_out_path_with_out_dir_and_src_root(tmp_path):
+    src_root = Path("/src")
+    inp = src_root / "movies/action/video.mp4"
+    out_dir = tmp_path / "dest"
+    preset = vidconv.Preset(name="test", suffix=".test", params=(), ext="mkv")
+    cfg = vidconv.Config()
+
+    out = vidconv.gen_out_path(inp, preset, cfg, out_dir=out_dir, src_root=src_root)
+
+    assert out == out_dir / "movies/action/video.test.mkv"
+    assert (out_dir / "movies/action").exists()


### PR DESCRIPTION
This PR adds a new test file `tests/test_vidconv_out_path.py` to provide unit test coverage for the `gen_out_path` function in the `vidconv.py` utility.

🎯 **What:** The testing gap addressed is the lack of unit tests for `gen_out_path`, which is responsible for determining the destination path of converted media files.
📊 **Coverage:** The new tests cover:
- Path calculation when no output directory is specified.
- Path calculation with a specified output directory.
- Recursive directory structure preservation when both source root and output directory are provided.
- Dynamic suffix generation based on `Config` and `Preset` parameters.
- Sanitization of suffix characters to ensure filesystem compatibility.
✨ **Result:** Increased reliability of the `vidconv` tool by ensuring output paths are correctly calculated and sanitized across different directory configurations.

---
*PR created automatically by Jules for task [10233208582975091854](https://jules.google.com/task/10233208582975091854) started by @Ven0m0*