### PR TITLE
🧪 Add error path test for set_device_permissions

### DIFF
--- a/tests/test_steelseries_perms.py
+++ b/tests/test_steelseries_perms.py
@@ -1,5 +1,8 @@
 import importlib.util
+import os
 import pathlib
+from unittest.mock import patch
+
 import pytest
 
 # Load the script as a module
@@ -48,3 +51,9 @@ def test_parse_usage_page_malformed():
     # Truncated long item
     assert steelseries_perms.parse_usage_page(b"\xFE") == 0
     assert steelseries_perms.parse_usage_page(b"\xFE\x01") == 0
+
+def test_set_device_permissions_error():
+    with patch("os.chmod") as mock_chmod:
+        mock_chmod.side_effect = OSError("Permission denied")
+        with pytest.raises(RuntimeError, match="Failed to set permissions"):
+            steelseries_perms.set_device_permissions("/dev/hidraw0")


### PR DESCRIPTION
This PR improves the testing of `etc/udev/rules.d/steelseries-perms.py` by adding a test case for the error handling path in `set_device_permissions`.

The new test `test_set_device_permissions_error` mocks `os.chmod` to raise an `OSError` and asserts that `steelseries_perms.set_device_permissions` wraps it in a `RuntimeError` with the appropriate message.

Key changes:
- Added `import os` and `from unittest.mock import patch` to `tests/test_steelseries_perms.py`.
- Implemented `test_set_device_permissions_error` in `tests/test_steelseries_perms.py`.

---
*PR created automatically by Jules for task [7809937722551382835](https://jules.google.com/task/7809937722551382835) started by @Ven0m0*